### PR TITLE
Dmsmvr 2561 summit demo data (#1)

### DIFF
--- a/accommodation_facilities.json
+++ b/accommodation_facilities.json
@@ -15,6 +15,21 @@
 					{ "room_type_id": "3", "count": 5, "capacity": 6 }
 				]
 			}
+		},
+		{
+			"accommodation_types": { "set": "21" },
+			"amenities": { "set": ["24_hour_front_desk", "express_check_in", "express_check_out", "fitness_facilities", "coffee_tea_maker", "concierge", "cable", "business_center", "hair_dryer", "pool_outdoor", "room_service", "multilingual_staff", "laundry_facilities", "iron", "spa", "early_check_in_available", "grab_bars_in_bathtub", "grab_bars_in_shower", "minifridge"] },
+			"cancellation_policy": "You may cancel your reservation for no charge before 11:59 PM local hotel time on February 14, 2024 (7 day[s] before arrival). Please note that we will assess a fee of 540.72 USD if you must cancel after this deadline. If you have made a prepayment, we will retain all or part of your prepayment. If not, we will charge your credit card.",
+			"check_in_time": "4:00 PM",
+			"check_out_time": "11:00 AM",
+			"property_id": "3",
+			"sleeping_rooms": {
+				"docs": [
+					{ "room_type_id": "1", "count": 180, "capacity": 2 },
+					{ "room_type_id": "2", "count": 360, "capacity": 4 },
+					{ "room_type_id": "3", "count": 35, "capacity": 6 }
+				]
+			}
 		}
 	]
 }

--- a/account_contacts.json
+++ b/account_contacts.json
@@ -15,6 +15,26 @@
 			"account_id":"8",
 			"contact_id":"2",
 			"title":"Facilities Engineer"
+		},
+		{
+			"account_id":"2",
+			"contact_id":"6",
+			"title":"Event Planner"
+		},
+		{
+			"account_id":"2",
+			"contact_id":"73",
+			"title":"General Manager"
+		},
+		{
+			"account_id":"2",
+			"contact_id":"25",
+			"title":"Sales and Services Coordinator"
+		},
+		{
+			"account_id":"2",
+			"contact_id":"11",
+			"title":"Director of Marketing"
 		}
 	]
 }

--- a/account_images.json
+++ b/account_images.json
@@ -60,6 +60,106 @@
 			"credits":"Staff Photo",
 			"is_publication_consent": true,
 			"is_deleted": false
+		},
+		{
+			"account_id":"2",
+			"title":"Bike Image",
+			"type_id":"image",
+			"file_id": "8",
+			"alt_text":"Bike Image",
+			"credits":"Staff Photo",
+			"is_publication_consent": true,
+			"is_deleted": false
+		},
+		{
+			"account_id":"2",
+			"title":"Night shot with stars",
+			"type_id":"image",
+			"file_id": "9",
+			"alt_text":"Night shot with stars night",
+			"is_publication_consent": true,
+			"is_deleted": false
+		},
+		{
+			"account_id":"2",
+			"title":"Hashani Spa Starr Pass",
+			"type_id":"image",
+			"file_id": "10",
+			"alt_text":"Hashani Spa Starr Pass",
+			"is_publication_consent": true,
+			"is_deleted": false
+		},
+		{
+			"account_id":"2",
+			"title":"JW Marriott Starr Pass Logo",
+			"type_id":"logo",
+			"file_id": "11",
+			"alt_text":"JW Marriott Starr Pass Logo",
+			"is_publication_consent": true,
+			"is_deleted": false
+		},
+		{
+			"account_id":"2",
+			"title":"Pool and Moon",
+			"type_id":"image",
+			"file_id": "12",
+			"alt_text":"Pool and Moon",
+			"is_publication_consent": true,
+			"is_deleted": false
+		},
+		{
+			"account_id":"2",
+			"title":"reflections pool view",
+			"type_id":"image",
+			"file_id": "13",
+			"alt_text":"reflections pool view",
+			"is_publication_consent": true,
+			"is_deleted": false
+		},
+		{
+			"account_id":"2",
+			"title":"SPG9",
+			"type_id":"image",
+			"file_id": "14",
+			"alt_text":"Golf course",
+			"is_publication_consent": true,
+			"is_deleted": false
+		},
+		{
+			"account_id":"2",
+			"title":"club logo",
+			"type_id":"logo",
+			"file_id": "15",
+			"alt_text":"club logo",
+			"is_publication_consent": true,
+			"is_deleted": false
+		},
+		{
+			"account_id":"2",
+			"title":"TUSSP Signature Shot",
+			"type_id":"image",
+			"file_id": "16",
+			"alt_text":"Signature Shot",
+			"is_publication_consent": true,
+			"is_deleted": false
+		},
+		{
+			"account_id":"2",
+			"title":"SP golfer teeing off",
+			"type_id":"image",
+			"file_id": "17",
+			"alt_text":"SP golfer teeing off",
+			"is_publication_consent": true,
+			"is_deleted": false
+		},
+		{
+			"account_id":"2",
+			"title":"wildlife wonders",
+			"type_id":"image",
+			"file_id": "18",
+			"alt_text":"wildlife wonders",
+			"is_publication_consent": true,
+			"is_deleted": false
 		}
 	]
 }

--- a/account_media.json
+++ b/account_media.json
@@ -20,6 +20,76 @@
 			"listing_id": "1",
 			"image_id": "6",
 			"sort_order": 4
+		},
+		{
+			"leisure_event_id": "5",
+			"image_id": "7",
+			"sort_order": 1
+		},
+		{
+			"offer_id": "3",
+			"image_id": "8",
+			"sort_order": 2
+		},
+		{
+			"offer_id": "4",
+			"image_id": "9",
+			"sort_order": 3
+		},
+		{
+			"listing_id": "2",
+			"image_id": "10",
+			"sort_order": 4
+		},
+		{
+			"listing_id": "2",
+			"image_id": "11",
+			"sort_order": 5
+		},
+		{
+			"listing_id": "2",
+			"image_id": "12",
+			"sort_order": 6
+		},
+		{
+			"listing_id": "2",
+			"image_id": "13",
+			"sort_order": 7
+		},
+		{
+			"listing_id": "7",
+			"image_id": "14",
+			"sort_order": 8
+		},
+		{
+			"listing_id": "7",
+			"image_id": "15",
+			"sort_order": 9
+		},
+		{
+			"listing_id": "7",
+			"image_id": "16",
+			"sort_order": 10
+		},
+		{
+			"listing_id": "7",
+			"image_id": "13",
+			"sort_order": 11
+		},
+		{
+			"leisure_event_id": "4",
+			"image_id": "17",
+			"sort_order": 12
+		},
+		{
+			"leisure_event_id": "4",
+			"image_id": "13",
+			"sort_order": 13
+		},
+		{
+			"listing_id": "2",
+			"video_id": "5",
+			"sort_order": 1
 		}
 	]
 }

--- a/account_videos.json
+++ b/account_videos.json
@@ -39,6 +39,15 @@
 			"credits":"KLIX - So Cal's Online Hotspot",
 			"is_publication_consent": true,
 			"is_deleted": false
+		},
+		{
+			"account_id":"2",
+			"title":"JW Marriott Starr Pass Virtual Property Tour",
+			"type_id":"youtube",
+			"external_id":"um2ctDKy28A",
+			"credits":"JW Marriott Starr Pass",
+			"is_publication_consent": true,
+			"is_deleted": false
 		}
 	]
 }

--- a/accounts.json
+++ b/accounts.json
@@ -35,16 +35,27 @@
 			}
 		},
 		{
-			"account_name": "Starr Pass Resort",
-			"former_account_name": "JW Marriott",
-			"weburl": "https://www.marriott.com/en-us/hotels/tussp-jw-marriott-tucson-starr-pass-resort-and-spa/overview/?scid=f2ae0541-1279-4f24-b197-a979c79310b0",
+			"account_name": "JW Marriott Tucson Starr Pass Resort & Spa",
+			"former_account_name": "Starr Pass Marriott Resort and Spa",
+			"weburl": "https://www.marriott.com/en-us/hotels/tussp-jw-marriott-tucson-starr-pass-resort-and-spa/overview/",
 			"account_description": "a luxury hotel with world-class golf, excellent dining and resort amenities near downtown Tucson.",
 			"keywords": "Hotel, Resort, Spa, Golf",
+			"email": "info@jwmarriottstarrpass.com",
 			"is_deleted": false,
 			"is_active": true,
+			"is_send_email": true,
 			"region_id": "7",
 			"engagement_level_id": "2",
 			"market_segment_id": "72",
+			"source_id": "3",
+			"social_facebook": "jwstarrpass",
+			"social_instagram": "jwstarrpass",
+			"social_x": "@JWStarrPass",
+			"tags": { "set": ["3"] },
+			"geo_coordinates": {
+				"lat": 32.2158531,
+				"long": -111.0500871
+			},
 			"groups": {
 				"set": [
 					"1",
@@ -65,6 +76,25 @@
 					"is_physical": true,
 					"is_shipping": false
 				}
+			},
+			"phones": {
+				"docs": [
+					{
+						"phone_number": "15207923500",
+						"is_primary": true,
+						"phone_type_id": "direct"
+					},
+					{
+						"phone_number": "18885278989",
+						"is_primary": false,
+						"phone_type_id": "toll_free"
+					},
+					{
+						"phone_number": "15207923351",
+						"is_primary": false,
+						"phone_type_id": "fax"
+					}
+				]
 			}
 		},
 		{

--- a/dining_facilities.json
+++ b/dining_facilities.json
@@ -22,6 +22,24 @@
 			"private_dining_capacity": 25,
 			"property_id": "1",
 			"reservation_link": "http://4thstreetmarket.com"
+		},
+		{
+			"amenities": {
+				"set": [
+					"accessible_restaurant",
+					"bar",
+					"champagne_service",
+					"smoke_free_property",
+					"lounge"
+				]
+			},
+			"cuisines": { "set": ["3"] },
+			"meals_served": { "set": ["3", "4"] },
+			"dining_types": { "set": ["1", "5"] },
+			"menu_link": "https://www.theclubatstarrpass.com/Files/Library/CBCOMENU1_12JSH2.PDF",
+			"price": { "set": "2" },
+			"property_id": "7",
+			"reservation_link": "https://www.opentable.com/r/catalina-sports-bar-tucson"
 		}
 	]
 }

--- a/files.json
+++ b/files.json
@@ -42,6 +42,78 @@
 			"name": "food truck round up.jpg",
 			"guid": "test7",
 			"file_size": 118441
+		},
+		{
+			"filestorage_id": "cloudinary://apex/account_images/file/440abfa3-e310-4cb6-9f1a-08cac912fa16-a-Bike-Race.jpg",
+			"name": "Bike-Race.jpg",
+			"guid": "cec570d8-4da7-4809-9c70-23fae11249e9",
+			"file_size": 135749
+		},
+		{
+			"filestorage_id": "cloudinary://apex/account_images/file/e21ed186-1c4c-4044-b7dd-e85e3699d5fe-a-Night-Shot-with-Stars_night.jpg",
+			"name": "Night-Shot-with-Stars_night.jpg",
+			"guid": "e32cc49e-b8ee-4eb0-b1f3-d95cbf5f70b1",
+			"file_size": 78540
+		},
+		{
+			"filestorage_id": "cloudinary://apex/account_images/file/ae8f57ca-e512-4cf0-8e0d-abe11dd4359c-a-Hashani-Spa-Starr-Pass.jpg",
+			"name": "Hashani-Spa-Starr-Pass.jpg",
+			"guid": "54293fb7-ee87-4e3e-9ab4-582a1328c412",
+			"file_size":1952619 
+		},
+		{
+			"filestorage_id": "cloudinary://apex/account_images/file/795b7d2c-56b3-4995-8a2a-a1f14d57654f-a-JWMarriottStarrPassLogo.jpg",
+			"name": "JWMarriottStarrPassLogo.jpg",
+			"guid": "29f12ba9-10d2-4934-904d-9b1b7dba041e",
+			"file_size": 12303
+		},
+		{
+			"filestorage_id": "cloudinary://apex/account_images/file/54eb4259-0999-4b91-ab63-69db6b26356d-a-Pool-and-Moon.jpg",
+			"name": "Pool-and-Moon.jpg",
+			"guid": "5e0f2167-89bc-41c6-a052-7ca9b498409b",
+			"file_size": 21032936
+		},
+		{
+			"filestorage_id": "cloudinary://apex/account_images/file/887335ce-12c9-454e-9730-7b2951c17b6d-a-reflections-pool-view.jpg",
+			"name": "reflections pool view.jpg",
+			"guid": "f56b5d3d-0bfe-45f6-8cbc-e9f92c951ed8",
+			"file_size": 358383
+		},
+		{
+			"filestorage_id": "cloudinary://apex/account_images/file/eb2a6606-0dc7-4c78-873c-e3014f03a1de-a-SPG9.jpg",
+			"name": "SPG9.jpg",
+			"guid": "8766a7cd-cc2d-454f-9766-24dda779535e",
+			"file_size": 237743
+		},
+		{
+			"filestorage_id": "cloudinary://apex/account_images/file/ab824325-bde7-4e17-a167-3ad3b3ebf53f-a-clublogo.png",
+			"name": "clublogo.png",
+			"guid": "0d40abaa-10c7-4f5a-85b0-9290ab7e3fe4",
+			"file_size": 46133
+		},
+		{
+			"filestorage_id": "cloudinary://apex/account_images/file/7b6c6ca9-0980-4a34-a9c3-de422fa4e8ec-a-1231505_TUSSP_Signature_Shot.jpg",
+			"name": "1231505_TUSSP_Signature_Shot.jpg",
+			"guid": "7876cae8-1d0f-4375-ab5b-8f4b2be3ba1a",
+			"file_size": 548507
+		},
+		{
+			"filestorage_id": "cloudinary://apex/account_images/file/bd8af92e-2dfd-4fec-8d67-a62ce7e9f07e-a-SP_golfer_teeing_off_5702.jpg",
+			"name": "SP_golfer_teeing_off_5702.jpg",
+			"guid": "a2b1693b-2a37-42ac-b9e7-7feb201be4be",
+			"file_size": 264206
+		},
+		{
+			"filestorage_id": "cloudinary://apex/account_images/file/b6a8ad80-77c5-4f56-98cc-033dd4235eaf-a-wildlife_wonders.png",
+			"name": "wildlife_wonders.png",
+			"guid": "03f9351a-5bb6-4210-9e36-88aa1dec0594",
+			"file_size": 731733 
+		},
+		{
+			"filestorage_id": "gcp://apex/meeting_facilities/floor_plans/a45c2cc1-a2ae-48da-8fae-346a59552098-a-Meeting-Space-Capacities.pdf",
+			"name": "Meeting-Space-Capacities.pdf",
+			"guid": "9d659683-e1fd-41ab-86bd-452202420911",
+			"file_size": 113911 
 		}
 	]
 }

--- a/leisure_events.json
+++ b/leisure_events.json
@@ -90,6 +90,78 @@
 			"doors_open": "8:00 AM",
 			"purchase_tickets": "https://www.4thstreetmarket.com/gift-cards",
 			"premium_upgrade": "https://www.4thstreetmarket.com/private-event-space#event-contact-form"
+		},
+		{
+			"account": { "set": "2" },
+			"categories": { "set": ["1", "2", "5"] },
+			"channels": { "set": ["1"] },
+			"description": "\"Wildlife Wonders\" is a juried exhibition of members of the Society of Animal Artists. Sixty original works by international artists, each a testament to the endless diversity of wildlife. From intricate sculptures to vibrant paintings, this collection heralds the wonders that inhabit our planet, from the smallest insects and birds to majestic predators.\nThese art works celebrate the natural world and help us see its beauty and resilience. They also serve to call our attention to the need for conservation.\nThe Society of Animal Artists (SAA) is an international organization for artists who paint, sculpt, or draw animals and wildlife, founded in 1960. \nOpening Art Reception \nFriday, March 8, 4:00 PM to 6:00 PM",
+			"date_rule_sets": {
+				"docs": [
+					{
+						"interval": null,
+						"end_option_id": null,
+						"frequency_id": "single_date",
+						"start_date_at": "2024-03-08T07:00:00.000Z",
+						"start_time": "04:00 PM",
+						"end_time": "06:00 PM"
+					},
+					{
+						"interval": 1,
+						"end_option_id": null,
+						"frequency_id": "daily",
+						"start_date_at": "2024-03-09T07:00:00.000Z",
+						"start_time": "10:00 AM",
+						"end_date_at": "2024-06-09T07:00:00.000Z",
+						"end_time": "04:00 PM"
+					}
+				]
+			},
+			"is_featured": true,
+			"title": "Wildlife Wonders - Juried Exhibition of the Society of Animal Artists",
+			"venue_listing": { "set": "2" },
+			"venue_type": { "set": "listing" },
+			"host_listing": { "set": "3" },
+			"host_type": { "set": "listing" },
+			"social_facebook": "SocietyOfAnimalArtists",
+			"social_instagram": "societyofanimalartists",
+			"weburl": "https://www.desertmuseumarts.com/wildlife-wonders",
+			"email": "arts@desertmuseum.org",
+			"phone": "(520) 883-3024",
+			"rank": { "set": "1" },
+			"post_from_at": "2024-03-01T07:00:00.000Z"			
+		},
+		{
+			"account": { "set": "2" },
+			"admission": "$45. Adults, Youth $25",
+			"categories": { "set": ["2", "7"] },
+			"channels": { "set": ["1","7"] },
+			"description": "The Amerind Museum presents the 5th Annual Texas Canyon Mountain Bike Race.  Saturday, May 18, 2024 is your opportunity to enjoy this awe-inspiring region that is normally closed to bikes. Experience mountain biking at its best on a course that takes you on one or two 7.9-mile loops through spectacular Texas Canyon. \nOpen to ages 12-99, participants may select from three event options, including a non-competitive e-bike course.  Awards will be given to overall Male and Female winners in both races and 1st through 3rd Place Male and Female in each race division.  Awards will not be given in the non-competitive e-bike division.\nRace Divisions: Jr Male/Female 12-19, Male/Female 20-59, Male/Female 60+\nAfter the awards ceremony simply show your bike plate number or free guest passes to the admissions desk for free entry into the Amerind Museum, Art Gallery and, Nature Preserve hiking trails included with registration.  Make a day of it!\nParticipation in the event enables Amerind to further its mission of fostering and promoting knowledge and understanding of the Native Peoples of the Americas through research, education, conservation, and community engagement.\nThe race starts at 7:30 am. for the 2 lap (15.8 mile) division and 7:40 am for the 1 lap (7.9 mile) division. E-bikes will start at 7:45 am - AFTER all competitive riders have cleared the start line.\n",
+			"date_rule_sets": {
+				"docs": [
+					{
+						"interval": null,
+						"end_option_id": null,
+						"frequency_id": "single_date",
+						"start_date_at": "2024-05-18T07:00:00.000Z",
+						"start_time": "07:30 AM",
+						"end_time": "11:00 AM"
+					}
+				]
+			},
+			"is_featured": true,
+			"title": "5th Annual Texas Canyon Mountain Bike Race",
+			"host_name": "Amerind Museum",
+			"host_type": { "set": "custom" },
+			"venue_listing": { "set": "7" },
+			"venue_type": { "set": "listing" },
+			"weburl": "https://www.amerind.org/events/texas-canyon-mountain-bike-race-5/",
+			"email": "mohnesorgen@amerind.org",
+			"phone": "(520) 686-1336",
+			"rank": { "set": "2" },
+			"post_from_at": "2024-03-01T07:00:00.000Z",
+			"purchase_tickets": "https://bit.ly/TCMBR24",
+			"doors_open": "7:30 AM"			
 		}
 	]
 }

--- a/listings.json
+++ b/listings.json
@@ -14,8 +14,12 @@
 			"title": "Starr Pass Resort - Accommodations - Resorts",
 			"description": "Welcome to JW Marriott Tucson Starr Pass Resort & Spa. A desert oasis near downtown Tucson, AZ. Stay where style and comfort intersect at JW Marriott Tucson Starr Pass Resort & Spa. Located near downtown Tucson, AZ, our hotel offers uncomplicated relaxation amid the city's top attractions. Featuring luxury amenities and excellent service, our downtown resort is a sanctuary where your comfort is always a certainty. Test your swing on the Arnold Palmer-designed desert golf courses, pamper yourself at our spa or take a dip in our multi-level pool and lazy river. Hike and bike on Tucson’s spectacular trails or explore Mountain Park, Kino Sports complex and Old Tucson Studios. In the evening, indulge in delicious cuisine in one of our resort's buzz-worthy restaurants before retreating to well-appointed rooms and suites with stylish decor, plush bedding and separate sitting areas. If visiting downtown Tucson for business or social events, succeed like never before in our sophisticated venues with room for up to 3,300 guests. Let JW Marriott Tucson Starr Pass Resort & Spa ensure a memorable stay.",
 			"keywords": "resort, spa, golf",
+			"is_featured": true,
+			"rank": { "set": "1" },
 			"property": { "set": "3" },
-			"subcategories": { "set": ["3"] }
+			"subcategories": { "set": ["3"] },
+			"channels": { "set": ["1","3"] },
+			"post_from_at": "2024-02-15T07:00:00.000Z"
 		},
 		{
 			"account": { "set": "8" },
@@ -46,6 +50,17 @@
 			"title": "4th Street Event Center Listing",
 			"property": { "set": "6" },
 			"property_id": "6"
+		},
+		{
+			"account": { "set": "2" },
+			"title": "Club at Starr Pass",
+			"property_id": "7",
+			"description": "27-holes of championship desert golf at your fingertips. Golf legends such as Arnold Palmer, Phil Mickelson, Payne Stewart and Nancy Lopez, to name a few, have all carved their way through this historic golf course. Today the legend continues as Arnold Palmer completed a redesign of the original 18-hole Cupp/Stadler layout and added a new nine holes making Starr Pass a 27-hole Championship Golf Course. The course is a true desert experience as all of the hazards are completely natural elements of the environment. The three nines, which wind their way through the mountains and arroyos, are aptly named after the ever-present desert wildlife: Rattler, Road Runner and Coyote. Starr Pass Golf Club was the host facility for the PGA Tour’s Tucson Open from 1988 to 1995.",
+			"keywords": "golf, coyote, rattler, palmer, road runner",
+			"subcategories": { "set": ["7", "18", "19"] },
+			"is_featured": true,
+			"rank": { "set": "1" },
+			"channels": { "set": ["1","3","7"] }
 		}
 	]
 }

--- a/meeting_facilities.json
+++ b/meeting_facilities.json
@@ -12,6 +12,22 @@
 			"property_id": "1",
 			"rooms": 20,
 			"meeting_facility_types": { "set": ["4"] }
+		},
+		{
+			"amenities": {
+				"set": [
+					"accessible_business_center_or_conference_rooms",
+					"service_animals_allowed",
+					"wedding_services",
+					"wifi_internet_free"
+				]
+			},
+			"property_id": "3",
+			"rooms": 30,
+			"meeting_facility_types": { "set": ["4","8"] },
+			"description": "We have 88,000 sq. ft. of fantastic indoor and outdoor event space! Our two ballrooms (14,670 sq. ft. and 19,836 sq. ft.) have 22' ft. high ceilings and separate foyer spaces with windows overlooking the Tucson Mountain Park. The foyers lead out onto the outdoor Ania Terrace overlooking the Golf Course and Mountain Park. Our additional meeting rooms (840 sq. ft. to 1,690 sq. ft.) have windows and terraces and our Boardrooms have executive chairs and windows as well. The Resort has one hallway that leads from the lobby to the meeting space ensuring guests find their way while enjoying the beautiful views of our golf course and mountains!",
+			"area": 8175.4675,
+			"floor_plans": { "set": ["19"]}
 		}
 	]
 }

--- a/meeting_rooms.json
+++ b/meeting_rooms.json
@@ -1,0 +1,58 @@
+{
+	"model": "meeting_rooms",
+	"data": [
+		{
+            "meeting_facility_id": "2",
+			"name": "Arizona Ballroom",
+            "type_id": "2",
+			"width": 53.0352,
+			"length": 34.7472,
+            "height": 5.7912,
+            "area": 1842.8247,
+            "partitions": 12,
+            "description": "Partitionable into 2 large rooms and 10 smaller",
+            "configurations": {
+				"docs": [
+					{ "type_id": "8", "column": "none", "capacity": 2000 },
+                    { "type_id": "4", "column": "none", "capacity": 1332 },
+                    { "type_id": "7", "column": "none", "capacity": 1900 },
+                    { "type_id": "2", "column": "none", "capacity": 980 }
+				]
+			}
+		},
+        {
+            "meeting_facility_id": "2",
+			"name": "Tucson Ballroom",
+            "type_id": "2",
+			"width": 49.6824,
+			"length": 27.432,
+            "height": 6.4008,
+            "area": 1362.8876,
+            "partitions": 12,
+            "description": "Partitionable into 2 large rooms and 10 smaller",
+            "configurations": {
+				"docs": [
+					{ "type_id": "8", "column": "none", "capacity": 1350 },
+                    { "type_id": "4", "column": "none", "capacity": 952 },
+                    { "type_id": "7", "column": "none", "capacity": 1300 },
+                    { "type_id": "2", "column": "none", "capacity": 780 }
+				]
+			}
+		},
+        {
+            "meeting_facility_id": "2",
+			"name": "Ania Terrace",
+            "type_id": "3",
+			"width": 52.4256,
+			"length": 17.0688,
+            "area": 1393.5456,
+            "description": "Select our Ania Terrace for a beautiful outdoor cocktail reception or other special event. Our creative design staff can set the stage for any type of gathering, making memories that will last.",
+            "configurations": {
+				"docs": [
+                    { "type_id": "7", "column": "none", "capacity": 800 },
+                    { "type_id": "2", "column": "none", "capacity": 600 }
+				]
+			}
+		}
+	]
+}

--- a/offers.json
+++ b/offers.json
@@ -25,6 +25,36 @@
 			"tags": { "set": ["2", "3"] },
 			"title": "My 4th Street Full Offer",
 			"weburl": "http://www.4thstreetmarket.com"
+		},
+		{
+			"account": { "set": "2" },
+			"categories": { "set": ["3"] },
+			"channels": { "set": ["1","3"] },
+			"listings": { "set": ["2"] },
+			"rank": { "set": "2" },
+			"is_featured": true,
+			"post_from_at": "2023-01-12T07:00:00.000Z",
+			"post_to_at": "2024-05-31T07:00:00.000Z",
+			"redeem_from_at": "2023-01-12T07:00:00.000Z",
+			"redeem_to_at": "2024-05-31T07:00:00.000Z",
+			"description": "Settle in and save on 5+ consecutive nights. Book by Monday,May 27, 2024. Minimum stay 5+ nights at hotels, 7+ nights at resorts.\nAvailable at participating properties in the U.S., Canada, Caribbean and Latin America only.\n\nUnlock amazing benefits. Join Marriott Bonvoy™.\nHow to Book\nBe sure that the Promotional Code appears in the Corporate/Promotional code box when making your online reservation, or call 1-800-228-9290 and ask for the promotional code. For toll-free numbers outside the US please visit Global Reservation Numbers\n",
+			"title": "Save on 5+ Nights",
+			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp"
+		},
+		{
+			"account": { "set": "2" },
+			"categories": { "set": ["2","3"] },
+			"channels": { "set": ["1"] },
+			"listings": { "set": ["2"] },
+			"rank": { "set": "2" },
+			"is_featured": true,
+			"post_from_at": "2023-12-01T07:00:00.000Z",
+			"post_to_at": "2025-01-01T07:00:00.000Z",
+			"redeem_from_at": "2024-01-01T07:00:00.000Z",
+			"redeem_to_at": "2025-01-15T07:00:00.000Z",
+			"description": "Escape to a world of serenity and relaxation with our Spa Retreats Package at the JW Marriott Starr Pass. \nUnwind, rejuvenate, and embrace the tranquility of every moment. Your retreat includes one 50 minute spa treatment per day, and a daily resort credit of $50. Your pathway to unparalleled is one click away.\nHow to Book\n\nBe sure that the Promotional Code appears in the Corporate/Promotional code box when making your online reservation, or call 520-791-6117 and ask for the promotional code. For toll-free numbers outside the US please visit Global Reservation Numbers\nNeed to Know\n\n    Promotional Code: SPA\n    Valid stay dates: January 18, 2024 - January 15, 2025\n",
+			"title": "Spa Retreats - Relax and Rejuvenate",
+			"weburl": "https://www.marriott.com/offers/spa-retreats-package-off-88552/tussp-jw-marriott-tucson-starr-pass-resort-and-spa?propertycode=tussp"
 		}
 	]
 }

--- a/properties.json
+++ b/properties.json
@@ -13,8 +13,34 @@
 		},
 		{
 			"account_id":"2",
-			"name":"Star Pass Property",
-			"property_type_id":"1"
+			"name":"JW Marriott Tucson Starr Pass Resort & Spa",
+			"property_type_id":"1",	
+			"brand":"JW Marriott",
+			"built_at":"2005-01-01T07:00:00.000Z",
+			"renovated_at":"2013-01-01T07:00:00.000Z",
+			"number_of_floors": 8,
+			"parking": { "set": ["1","2","3","4","6","8"] },
+			"languages_spoken": { "set": ["4","5","15"] },
+			"contact_id":"11",
+			"threshold360_id": "7684201-200189",
+			"yelp_id": "jw-marriotttucson-starr-pass-resort-and-spa-tucson",
+			"tripadvisor_id": "503078",
+			"tripadvisor_category_id": "hotel",
+			"amenities": {
+				"set": [
+					"airport_shuttle",
+					"atm_banking_on_site",
+					"business_center",
+					"conference_center",
+					"multilingual_staff",
+					"outdoor_ramps",
+					"service_animals_allowed",
+					"smoke_free_property",
+					"wheelchair_accessible_elevator",
+					"wheelchair_width_doors",
+					"wifi_internet_free"
+				]
+			}
 		},
 		{
 			"account_id":"8",
@@ -30,6 +56,60 @@
 			"account_id":"13",
 			"name":"4th Street Event Center",
 			"property_type_id":"6"
+		},
+		{
+			"account_id":"2",
+			"name":"The Club at Starr Pass",
+			"property_type_id":"6",
+			"built_at":"1986-01-01T07:00:00.000Z",
+			"renovated_at":"1993-01-01T07:00:00.000Z",
+			"parking": { "set": ["1","2","3","4","6","8"] },
+			"contact_id":"25",
+			"weburl":"https://www.theclubatstarrpass.com/",
+			"email": "info@theclubatstarrpass.com",
+			"geo_coordinates": {
+				"lat": 32.2088722,
+				"long": -111.0431067
+			},
+			"social_facebook":"starrpassgc",
+			"social_instagram":"theclubatstarrpass",
+			"social_youtube":"@troon",
+			"amenities": {
+				"set": [
+					"airport_shuttle",
+					"atm_banking_on_site",
+					"desert_view",
+					"multilingual_staff",
+					"outdoor_entertainment_area",
+					"outdoor_ramps",
+					"pool_outdoor",
+					"service_animals_allowed",
+					"smoke_free_property",
+					"spa",
+					"terrace"
+				]
+			},
+			"phones": {
+				"docs": [
+					{
+						"phone_number": "15209008210",
+						"is_primary": true,
+						"phone_type_id": "direct"
+					}
+				]
+			},
+			"addresses": {
+				"docs": {
+					"address_line_1": "3645 W. Starr Pass Blvd",
+					"address_line_2": null,
+					"address_line_3": null,
+					"city": "Tucson",
+					"state_id": "US_AZ",
+					"postal_code": "85713",
+					"country_id": "US",
+					"is_physical": true
+				}
+			}
 		}
 	]
 }

--- a/sports_facilities.json
+++ b/sports_facilities.json
@@ -1,0 +1,24 @@
+{
+	"model": "sports_facilities",
+	"data": [
+		{
+			"amenities": {
+				"set": [
+					"coaching",
+					"golf_cart",
+					"golf_clubhouse",
+					"golf_driving_range",
+					"golf_equipment",
+                    "golfing_lessons",
+                    "golf_pro_shop",
+                    "green_fees"
+				]
+			},
+            "designer_architect": "Bob Cupp, Craig Stadler and Arnold Palmer",
+			"property_id": "7",
+            "sports_facility_types": { "set": "4" },
+			"sports": { "set": ["31"] },
+			"year_established_at": "1986-01-01T07:00:00.000Z"			
+		}
+	]
+}

--- a/sports_facility_spaces.json
+++ b/sports_facility_spaces.json
@@ -1,0 +1,31 @@
+{
+	"model": "sports_facility_spaces",
+	"data": [
+		{
+            "sports_facility_id": "1",
+			"name": "Rattler",
+            "type_id": "8",
+			"location_id": "outdoor",
+			"surface_types": {"set": [ "1" ] },
+            "configurations": {
+				"docs": [
+					{ "type_id": "5", "column": "none", "capacity": 1 }
+				]
+			}
+		},
+        {
+            "sports_facility_id": "1",
+			"name": "Roadrunner",
+            "type_id": "8",
+			"location_id": "outdoor",
+			"surface_types": {"set": [ "1" ] }
+		},
+        {
+            "sports_facility_id": "1",
+			"name": "Coyote",
+            "type_id": "8",
+			"location_id": "outdoor",
+			"surface_types": {"set": [ "1" ] }
+		}
+	]
+}

--- a/sports_facility_spaces.json
+++ b/sports_facility_spaces.json
@@ -9,7 +9,7 @@
 			"surface_types": {"set": [ "1" ] },
             "configurations": {
 				"docs": [
-					{ "type_id": "5", "column": "none", "capacity": 1 }
+					{ "type_id": "5", "column": "none", "count": 1 }
 				]
 			}
 		},


### PR DESCRIPTION
Ticket: https://simpleviewtools.atlassian.net/browse/DMSMVR-2651

## Description
Please refer ticket for details of demo data being added
Document referred: https://docs.google.com/document/d/1YAA55wsaH_wtf8BmDmhEeHzDu3tXO1MAovP-fOWBT-c

## Dev notes
This needs to be tested in tandem with https://github.com/simpleviewinc/dms/pull/674

Settings for 'Prepare Demo data' script 
{
	"user": "subaya710",
	"branch": "DMSMVR-2651-SummitDemoData"
}

## Additional notes 

- Coordinates not visible in account : https://test.local.simpleviewdms.dev/accounts/summary/2/
- Amenities present only in one column for property and does not justify across entire row : https://test.local.simpleviewdms.dev/properties/summary/7/
- Meeting room capacity is not persisted when we edit a meeting room : https://test.local.simpleviewdms.dev/properties/summary/3/_/meeting_facility/
- File showing as logo in “all account images” shows as image and not logo under listing

Total capacity under meeting facility and premium upgrade under event 2 have no value
