### PR TITLE
DMSMVR-2650: Update time formats for leisure_events data

### DIFF
--- a/leisure_events.json
+++ b/leisure_events.json
@@ -12,7 +12,8 @@
 						"end_option_id": null,
 						"frequency_id": "single_date",
 						"start_date_at": "2024-01-05T07:00:00.000Z",
-						"start_time": "5:00 PM"
+						"start_time": "17:00",
+						"end_time": "18:00"
 					}
 				]
 			},
@@ -36,7 +37,8 @@
 						"end_option_id": "date",
 						"frequency_id": "weekly",
 						"start_date_at": "2024-01-12T07:00:00.000Z",
-						"start_time": "7:00 PM"
+						"start_time": "19:00",
+						"end_time": "20:00"
 					}
 				]
 			},
@@ -68,7 +70,8 @@
 						"end_option_id": "occurrences",
 						"frequency_id": "weekly",
 						"start_date_at": "2024-01-05T07:00:00.000Z",
-						"start_time": "2:00 PM"
+						"start_time": "14:00",
+						"end_time": "17:00"
 					}
 				]
 			},
@@ -87,7 +90,7 @@
 			"venue_listing": { "set": "1" },
 			"venue_type": { "set": "listing" },
 			"weburl": "http://www.4thstreetmarket.com",
-			"doors_open": "8:00 AM",
+			"doors_open": "08:00",
 			"purchase_tickets": "https://www.4thstreetmarket.com/gift-cards",
 			"premium_upgrade": "https://www.4thstreetmarket.com/private-event-space#event-contact-form"
 		},


### PR DESCRIPTION
Ticket: [DMSMVR-2650](https://simpleviewtools.atlassian.net/browse/DMSMVR-2650)

## Description
The format for "time" fields has been changed `HH:mm` to align with the string format returned by the Mosaic [FormFieldTimeField](https://simpleviewinc.github.io/sv-mosaic/staging/?path=/docs/components-form-readme--page#formfieldtimefield)