### PR TITLE
DMSMVR-2697: Change room_blocks hotel relationships from accounts to properties

### DIFF
--- a/room_blocks.json
+++ b/room_blocks.json
@@ -11,7 +11,7 @@
 			"hotels": {
 				"docs": [
 					{
-						"account_id": "1",
+						"property_id": "8",
 						"contact_id": "1",
 						"is_awarded": true,
 						"is_headquarters": true,
@@ -214,7 +214,7 @@
 						}
 					},
 					{
-						"account_id": "2",
+						"property_id": "3",
 						"contact_id": "6",
 						"is_awarded": false,
 						"is_headquarters": false,
@@ -316,7 +316,7 @@
 			"hotels": {
 				"docs": [
 					{
-						"account_id": "2",
+						"property_id": "3",
 						"contact_id": "6",
 						"is_awarded": true,
 						"is_headquarters": false,
@@ -445,7 +445,7 @@
 			"hotels": {
 				"docs": [
 					{
-						"account_id": "55",
+						"property_id": "52",
 						"contact_id": "132",
 						"is_awarded": true,
 						"is_headquarters": true,
@@ -597,7 +597,7 @@
 			"hotels": {
 				"docs": [
 					{
-						"account_id": "47",
+						"property_id": "44",
 						"contact_id": null,
 						"is_awarded": false,
 						"is_headquarters": false,
@@ -652,7 +652,7 @@
 						}
 					},
 					{
-						"account_id": "58",
+						"property_id": "55",
 						"contact_id": "38",
 						"is_awarded": true,
 						"is_headquarters": true,
@@ -819,7 +819,7 @@
 			"hotels": {
 				"docs": [
 					{
-						"account_id": "25",
+						"property_id": "24",
 						"contact_id": "6",
 						"is_awarded": true,
 						"is_headquarters": true,


### PR DESCRIPTION
[DMSMVR-2697](https://simpleviewtools.atlassian.net/browse/DMSMVR-2697)

Room blocks are now related directly to properties instead of accounts. This PR updates the demo data as needed:

- Cookies to go (Opportunity ID 1)
    - "Cookies VIP" Room Block Hotels
        - _The 1895 House_ - **account_id 1** => **property_id 8**
        - _JW Marriott Tucson Starr Pass Resort & Spa_ - **account_id 2** => **property_id 3**
    - "Attendees" Room Block Hotel
        - _JW Marriott Tucson Starr Pass Resort & Spa_ - **account_id 2** => **property_id 3**
- Fiona's Wedding (Opportunity ID 4)
    - "Barnes/Fiore Wedding Guests" Room Block Hotels
        - _Comfort Suites_ - **account_id 55** => **property_id 52**
    - "Barnes/Fiore Wedding Party" Room Block Hotels
        - _Springhill Suites_ - **account_id 47** => **property_id 44**
        - Highland House Hotel_ - **account_id 58** => **property_id 55**
- Restaurants Europe 2023 (Opportunity ID 8)
    - "Attendees" Room Block Hotels
        - _Four Points by Sheraton Manhattan Chelsea_ - **account_id 25** => **property_id 24**

[DMSMVR-2697]: https://simpleviewtools.atlassian.net/browse/DMSMVR-2697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ