### PR TITLE
DMSMVR-2949: Account Images Broken in Demo Data

### DIFF
--- a/accounts.json
+++ b/accounts.json
@@ -35,7 +35,7 @@
 			}
 		},
 		{
-			"account_name": "JW Marriott Tucson Starr Pass Resort & Spa",
+			"account_name": "JW Marriott Tucson Starr Pass Resort & Spa 2",
 			"former_account_name": "Starr Pass Marriott Resort and Spa",
 			"weburl": "https://www.marriott.com/en-us/hotels/tussp-jw-marriott-tucson-starr-pass-resort-and-spa/overview/",
 			"account_description": "a luxury hotel with world-class golf, excellent dining and resort amenities near downtown Tucson.",

--- a/files.json
+++ b/files.json
@@ -50,63 +50,63 @@
 			"file_size": 135749
 		},
 		{
-			"filestorage_id": "cloudinary://apex/account_images/file/e21ed186-1c4c-4044-b7dd-e85e3699d5fe-a-Night-Shot-with-Stars_night.jpg",
+			"filestorage_id": "cloudinary://apex/account_images/file/363ae2d3-eb9f-456e-84ef-7a023cdba15c-a-Night-Shot-with-Stars_night.jpg",
 			"name": "Night-Shot-with-Stars_night.jpg",
-			"guid": "e32cc49e-b8ee-4eb0-b1f3-d95cbf5f70b1",
+			"guid": "1c223c37-265a-4176-b404-c1c5400823a4",
 			"file_size": 78540
 		},
 		{
-			"filestorage_id": "cloudinary://apex/account_images/file/ae8f57ca-e512-4cf0-8e0d-abe11dd4359c-a-Hashani-Spa-Starr-Pass.jpg",
+			"filestorage_id": "cloudinary://apex/account_images/file/7fc139a1-9f44-4897-9628-9a355722a6db-a-Hashani-Spa-Starr-Pass.jpg",
 			"name": "Hashani-Spa-Starr-Pass.jpg",
-			"guid": "54293fb7-ee87-4e3e-9ab4-582a1328c412",
+			"guid": "5bf284ff-5d0b-4ae2-98ea-81ae1f5d8952",
 			"file_size":1952619 
 		},
 		{
-			"filestorage_id": "cloudinary://apex/account_images/file/795b7d2c-56b3-4995-8a2a-a1f14d57654f-a-JWMarriottStarrPassLogo.jpg",
+			"filestorage_id": "cloudinary://apex/account_images/file/2b8852e4-1b5c-477c-a411-d02e1138f1a4-a-JWMarriottStarrPassLogo.jpg",
 			"name": "JWMarriottStarrPassLogo.jpg",
-			"guid": "29f12ba9-10d2-4934-904d-9b1b7dba041e",
+			"guid": "9db2ae9d-3a41-4e9e-95f6-71477a17a5f4",
 			"file_size": 12303
 		},
 		{
-			"filestorage_id": "cloudinary://apex/account_images/file/54eb4259-0999-4b91-ab63-69db6b26356d-a-Pool-and-Moon.jpg",
+			"filestorage_id": "cloudinary://apex/account_images/file/8e2c24b8-b21d-4f72-94ad-714b3a559364-a-Pool-and-Moon.jpg",
 			"name": "Pool-and-Moon.jpg",
-			"guid": "5e0f2167-89bc-41c6-a052-7ca9b498409b",
+			"guid": "48014d5d-4f37-4070-89f0-4bc341a622d9",
 			"file_size": 21032936
 		},
 		{
-			"filestorage_id": "cloudinary://apex/account_images/file/887335ce-12c9-454e-9730-7b2951c17b6d-a-reflections-pool-view.jpg",
+			"filestorage_id": "cloudinary://apex/account_images/file/e16b4e78-28f2-4baf-8523-fc2dde7b9505-a-reflections-pool-view.jpg",
 			"name": "reflections pool view.jpg",
-			"guid": "f56b5d3d-0bfe-45f6-8cbc-e9f92c951ed8",
+			"guid": "9630db76-1c5b-4d45-979b-99a4020ed5a3",
 			"file_size": 358383
 		},
 		{
-			"filestorage_id": "cloudinary://apex/account_images/file/eb2a6606-0dc7-4c78-873c-e3014f03a1de-a-SPG9.jpg",
+			"filestorage_id": "cloudinary://apex/account_images/file/016b3696-cd3b-4193-9aea-945e58d5f09b-a-SPG9.jpg",
 			"name": "SPG9.jpg",
-			"guid": "8766a7cd-cc2d-454f-9766-24dda779535e",
+			"guid": "a9fbe450-5758-45ee-8c71-aa60c64a681d",
 			"file_size": 237743
 		},
 		{
-			"filestorage_id": "cloudinary://apex/account_images/file/ab824325-bde7-4e17-a167-3ad3b3ebf53f-a-clublogo.png",
+			"filestorage_id": "cloudinary://apex/account_images/file/2b30b8d3-6767-41db-a9de-48d64afc105a-a-clublogo.png",
 			"name": "clublogo.png",
-			"guid": "0d40abaa-10c7-4f5a-85b0-9290ab7e3fe4",
+			"guid": "968def31-9485-4a72-8012-0ea602fb6142",
 			"file_size": 46133
 		},
 		{
-			"filestorage_id": "cloudinary://apex/account_images/file/7b6c6ca9-0980-4a34-a9c3-de422fa4e8ec-a-1231505_TUSSP_Signature_Shot.jpg",
+			"filestorage_id": "cloudinary://apex/account_images/file/e0181e8a-29df-4d14-b8f7-636d3c5cdf95-a-1231505_TUSSP_Signature_Shot.jpg",
 			"name": "1231505_TUSSP_Signature_Shot.jpg",
-			"guid": "7876cae8-1d0f-4375-ab5b-8f4b2be3ba1a",
+			"guid": "c3409857-ccdb-4278-9cb3-7f6e427afdaa",
 			"file_size": 548507
 		},
 		{
-			"filestorage_id": "cloudinary://apex/account_images/file/bd8af92e-2dfd-4fec-8d67-a62ce7e9f07e-a-SP_golfer_teeing_off_5702.jpg",
+			"filestorage_id": "cloudinary://apex/account_images/file/31841ac6-0941-4ffd-8443-462c6de6a874-a-SP_golfer_teeing_off_5702.jpg",
 			"name": "SP_golfer_teeing_off_5702.jpg",
-			"guid": "a2b1693b-2a37-42ac-b9e7-7feb201be4be",
+			"guid": "77ca7b32-64cc-458e-be66-64eef2216f02",
 			"file_size": 264206
 		},
 		{
-			"filestorage_id": "cloudinary://apex/account_images/file/b6a8ad80-77c5-4f56-98cc-033dd4235eaf-a-wildlife_wonders.png",
+			"filestorage_id": "cloudinary://apex/account_images/file/d925b7df-4906-40d4-a503-78ff3628a870-a-wildlife_wonders.png",
 			"name": "wildlife_wonders.png",
-			"guid": "03f9351a-5bb6-4210-9e36-88aa1dec0594",
+			"guid": "96f6a8dd-65bd-4bb5-bcd7-dbbe0c073d2d",
 			"file_size": 731733 
 		},
 		{
@@ -116,21 +116,21 @@
 			"file_size": 113911 
 		},
 		{
-			"filestorage_id": "cloudinary://apex/account_images/file/faf659da-8ecb-4c23-bcf4-e7a6cecea0dc-a-primo-patio-starr-pass.jpg",
+			"filestorage_id": "cloudinary://apex/account_images/file/7b387d78-568a-4f17-b542-359b2de6e714-a-primo-patio-starr-pass.jpg",
 			"name": "primo-patio-starr-pass.jpg",
-			"guid": "c9aef2d9-399a-4684-a85c-afd7165c95ce",
+			"guid": "312fab67-4961-4d57-8331-ab4687c9c464",
 			"file_size": 11161146 
 		},
 		{
-			"filestorage_id": "cloudinary://apex/account_images/file/f3d95d9b-c4e2-445b-b105-d74ca09d9980-a-Clubhouse_Pool.JPG",
+			"filestorage_id": "cloudinary://apex/account_images/file/17282d0c-aaf6-4ffb-ae94-7b8f89b82427-a-Clubhouse_Pool.JPG",
 			"name": "Clubhouse_Pool.JPG",
-			"guid": "3da9b183-efb1-4b29-9d65-163eaa5f296a",
+			"guid": "95ad1f2e-1e8f-46ff-90f2-2ec434421b60",
 			"file_size": 158814 
 		},
 		{
-			"filestorage_id": "cloudinary://apex/account_images/file/e0f08416-e4ab-4df3-8b72-2579a73dda2a-a-SP_main_building_horiz_4441.jpg",
+			"filestorage_id": "cloudinary://apex/account_images/file/1f102831-2dc4-48cf-87fb-8448be91e7c3-a-SP_main_building_horiz_4441.jpg",
 			"name": "SP_main_building_horiz_4441.jpg",
-			"guid": "c23419ab-a310-450b-8cb4-431a3e047051",
+			"guid": "73e82b3b-77dc-4fda-bb2b-96dbddd3a966",
 			"file_size": 549447 
 		}
 	]

--- a/files.json
+++ b/files.json
@@ -44,9 +44,9 @@
 			"file_size": 118441
 		},
 		{
-			"filestorage_id": "cloudinary://apex/account_images/file/440abfa3-e310-4cb6-9f1a-08cac912fa16-a-Bike-Race.jpg",
+			"filestorage_id": "cloudinary://apex/account_images/file/a3a1b8d1-f2cd-4368-8412-a7fa273fc310-a-Bike-Race.jpg",
 			"name": "Bike-Race.jpg",
-			"guid": "cec570d8-4da7-4809-9c70-23fae11249e9",
+			"guid": "ea57483a-b2a8-45b5-ad8f-775dfe35ff86",
 			"file_size": 135749
 		},
 		{


### PR DESCRIPTION
Ticket: https://simpleviewtools.atlassian.net/browse/DMSMVR-2949

Fixed the issues with JW Marriott Tucson Starr Pass Resort & Spa having missing images.

QA:

1. Run the Prepare Demo script with the following options:

{
	"user": "bsabney",
	"branch": "DMSMVR-2949--Account-Images-Broken-in-Demo-Data"
}

2.  After that is done, you can go and see if the images are all present now at:

https://test.local.simpleviewapex.dev/accounts/summary/2/_/account_images/

If the images are all present and visible, then this ticket has been completed.