### PR TITLE
DMSMVR-3293: Move-all-generated-tables-created-via-Configurable-Fields-to-new-schema

### DIFF
--- a/configurable_fields.json
+++ b/configurable_fields.json
@@ -79,6 +79,20 @@
 			"label": "Checkboxes Field",
 			"type_id": "checkbox",
 			"options_module_id": "sf_custom2"
+		},
+		{
+			"is_number_whole_numbers": false,
+			"is_text_multiline": false,
+			"label": "Brochure Checkboxes",
+			"options_module": {"set": "brochures"},
+			"type": {"set": "checkbox"}
+		},
+		{
+			"is_number_whole_numbers": false,
+			"is_text_multiline": false,
+			"label": "Account Tags Checkboxes",
+			"options_module": {"set": "account_tags"},
+			"type": {"set": "checkbox"}
 		}
 	]
 }

--- a/module_configurable_fields.json
+++ b/module_configurable_fields.json
@@ -212,6 +212,18 @@
 			"module": "account_videos",
 			"name": "text",
 			"label": "Text Field"
+		},
+		{
+			"configurable_field_id": "16",
+			"module": "contacts",
+			"name": "account_tags",
+			"label": "Account Tags"
+		},
+		{
+			"configurable_field_id": "15",
+			"module": "contacts",
+			"name": "brochures",
+			"label": "Brochures"
 		}
 	]
 }


### PR DESCRIPTION
Added some configurable fields with schema: public to verify this fix.

Settings for prepare-demo script to test the demo data:

{
	"user": "bsabney",
	"branch": "DMSMVR-3293-Move-all-generated-tables-created-via-Configurable-Fields-to-new-schema"
}