### PR TITLE
DMSMVR-3677: Add Support for Configurable Fields in CSV Export

### DIFF
--- a/data/contacts_ext.json
+++ b/data/contacts_ext.json
@@ -9,7 +9,7 @@
 			"decimal": 7.25,
 			"date_at": "2024-03-08T07:00:00.000Z",
 			"datetime_at": "2024-04-07T15:45:00.000Z",
-			"time": "15:00",
+			"time": "15:00:00",
 			"phone": "+15209751234",
 			"url": "https://www.google.com/",
 			"is_toggle": true,
@@ -20,6 +20,22 @@
 			},
 			"checkbox": {
 				"set": ["1","3"]
+			},
+			"email": "aaron.bilkins@gmail.com",
+			"is_yes_no_radio": true,
+			"address": {
+				"doc": {
+					"address_line_1": "5700 North Sabino Canyon Road",
+					"address_line_2": "",
+					"address_line_3": null,
+					"city": "Tucson",
+					"country_id": "US",
+					"postal_code": "85750",
+					"state_id": "US_AZ",
+					"is_physical": true,
+					"is_shipping": false,
+					"is_billing": false
+				}
 			}
 		},
 		{

--- a/data/module_configurable_fields.json
+++ b/data/module_configurable_fields.json
@@ -124,6 +124,12 @@
 			"label": "Checkboxes Field"
 		},
 		{
+			"configurable_field_id": "15",
+			"module": "contacts",
+			"name": "address",
+			"label": "Address"
+		},
+		{
 			"configurable_field_id": "16",
 			"module": "contacts",
 			"name": "email",


### PR DESCRIPTION
Ticket: [DMSMVR-3677](https://simpleviewtools.atlassian.net/browse/DMSMVR-3677)

Adds the 'address' config field type to the 'contacts' module, and some test data for all config field types to make it easier to QA config fields CSV grid export.

[DMSMVR-3677]: https://simpleviewtools.atlassian.net/browse/DMSMVR-3677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ