### PR TITLE
DMSMVR-5073: Update Prepare Demo LEO Publishing validation

### DIFF
--- a/data/accounts.json
+++ b/data/accounts.json
@@ -10,7 +10,7 @@
 			"is_deleted": false,
 			"is_active": true,
 			"region_id": "6",
-			"engagement_level_id": "1",
+			"engagement_level_id": "2",
 			"market_segment_id": "72",
 			"groups": {
 				"set": [
@@ -180,7 +180,7 @@
 			"is_deleted": false,
 			"is_active": true,
 			"region_id": "2",
-			"engagement_level_id": "1",
+			"engagement_level_id": "2",
 			"market_segment_id": "72",
 			"groups": {
 				"set": [
@@ -388,7 +388,7 @@
 			"is_deleted": false,
 			"is_active": true,
 			"region_id": "1",
-			"engagement_level_id": "1",
+			"engagement_level_id": "2",
 			"market_segment_id": "71",
 			"groups": {
 				"set": [
@@ -542,7 +542,7 @@
 			"is_deleted": false,
 			"is_active": true,
 			"region_id": "2",
-			"engagement_level_id": "1",
+			"engagement_level_id": "2",
 			"market_segment_id": "71",
 			"groups": {
 				"set": [
@@ -605,7 +605,7 @@
 			"is_deleted": false,
 			"is_active": true,
 			"region_id": "2",
-			"engagement_level_id": "1",
+			"engagement_level_id": "2",
 			"market_segment_id": "72",
 			"groups": {
 				"set": [
@@ -632,7 +632,7 @@
 			"is_deleted": false,
 			"is_active": true,
 			"region_id": "6",
-			"engagement_level_id": "1",
+			"engagement_level_id": "2",
 			"market_segment_id": "48_49",
 			"groups": {
 				"set": [
@@ -948,7 +948,7 @@
 			"is_deleted": false,
 			"is_active": true,
 			"region_id": "6",
-			"engagement_level_id": "1",
+			"engagement_level_id": "2",
 			"market_segment_id": "72",
 			"groups": {
 				"set": [
@@ -1050,7 +1050,7 @@
 			"is_deleted": false,
 			"is_active": true,
 			"region_id": "6",
-			"engagement_level_id": "1",
+			"engagement_level_id": "2",
 			"market_segment_id": "72",
 			"groups": {
 				"set": [
@@ -1627,7 +1627,7 @@
 			"is_deleted": false,
 			"is_active": true,
 			"region_id": "5",
-			"engagement_level_id": "1",
+			"engagement_level_id": "2",
 			"market_segment_id": "72",
 			"groups": {
 				"set": [
@@ -2159,7 +2159,7 @@
 			"is_deleted": false,
 			"is_active": true,
 			"region_id": "2",
-			"engagement_level_id": "1",
+			"engagement_level_id": "2",
 			"market_segment_id": "23",
 			"groups": {
 				"set": [
@@ -2466,7 +2466,7 @@
 			"is_deleted": false,
 			"is_active": true,
 			"region_id": "2",
-			"engagement_level_id": "1",
+			"engagement_level_id": "2",
 			"market_segment_id": "72",
 			"groups": {
 				"set": [
@@ -2735,7 +2735,7 @@
 			"is_deleted": false,
 			"is_active": true,
 			"region_id": "6",
-			"engagement_level_id": "1",
+			"engagement_level_id": "2",
 			"market_segment_id": "72",
 			"groups": {
 				"set": [
@@ -2768,7 +2768,7 @@
 			"is_deleted": false,
 			"is_active": true,
 			"region_id": "7",
-			"engagement_level_id": "1",
+			"engagement_level_id": "2",
 			"market_segment_id": "72",
 			"groups": {
 				"set": [

--- a/data/leisure_events.json
+++ b/data/leisure_events.json
@@ -21,7 +21,8 @@
 			"offers": null,
 			"title": "My 4th Street Simple Event",
 			"venue_listing": { "set": "1" },
-			"venue_type": { "set": "listing" }
+			"venue_type": { "set": "listing" },
+			"channels": { "set": ["1"] }
 		},
 		{
 			"account": { "set": "114" },
@@ -46,7 +47,8 @@
 			"offers": null,
 			"title": "611 Pub Simple Event",
 			"venue_listing": { "set": "4" },
-			"venue_type": { "set": "listing" }
+			"venue_type": { "set": "listing" },
+			"channels": { "set": ["1"] }
 		},
 		{
 			"account": { "set": "13" },
@@ -79,7 +81,7 @@
 			"phone": "+15205751151",
 			"rank": { "set": "1" },
 			"post_from_at": "2026-01-18T07:00:00.000Z",
-			"post_to_at": "2026-01-21T07:00:00.000Z",
+			"post_to_at": "2027-12-31T07:00:00.000Z",
 			"social_facebook": "4thstreetmarket",
 			"social_instagram": "4thstreetmarket",
 			"social_tiktok": "@4thstreetmarket",

--- a/data/leisure_events_automated.json
+++ b/data/leisure_events_automated.json
@@ -13,7 +13,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-07-14T07:00:00.000Z",
+					"start_date_at": "2024-07-14T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -31,7 +31,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-09-02T07:00:00.000Z",
+					"start_date_at": "2025-09-02T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -49,7 +49,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-01-13T07:00:00.000Z",
+					"start_date_at": "2024-01-13T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -67,7 +67,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-01-12T07:00:00.000Z",
+					"start_date_at": "2024-01-12T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -85,7 +85,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-05-17T07:00:00.000Z",
+					"start_date_at": "2026-05-17T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -103,7 +103,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-07-17T07:00:00.000Z",
+					"start_date_at": "2024-07-17T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -121,7 +121,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-11-01T07:00:00.000Z",
+					"start_date_at": "2025-11-01T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -139,7 +139,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-10-04T07:00:00.000Z",
+					"start_date_at": "2024-10-04T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -157,7 +157,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-02-20T07:00:00.000Z",
+					"start_date_at": "2025-02-20T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -175,7 +175,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-05-06T07:00:00.000Z",
+					"start_date_at": "2024-05-06T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -193,7 +193,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-08-19T07:00:00.000Z",
+					"start_date_at": "2024-08-19T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -211,7 +211,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-09-11T07:00:00.000Z",
+					"start_date_at": "2024-09-11T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -229,7 +229,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-01-18T07:00:00.000Z",
+					"start_date_at": "2025-01-18T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -247,7 +247,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-08-23T07:00:00.000Z",
+					"start_date_at": "2024-08-23T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -262,204 +262,6 @@
 				]
 			},
 			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-10-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-06-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Photography Contest Awards",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Business Leadership Conference",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-11-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Comedy Night Live",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Comedy Night Live",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sustainable Living Seminar",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
@@ -477,11 +279,11 @@
 					"1"
 				]
 			},
-			"title": "Science Fair Showcase",
+			"title": "Book Launch Party",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-06-12T07:00:00.000Z",
+					"start_date_at": "2026-06-20T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -490,186 +292,6 @@
 		},
 		{
 			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Annual Charity Gala",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Charity Fun Run",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-07-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-10-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Networking Mixer Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Startup Pitch Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-11T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Photography Contest Awards",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-12-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
 			"channels": {
 				"set": [
 					"1"
@@ -679,7 +301,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-09-23T07:00:00.000Z",
+					"start_date_at": "2025-12-24T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -687,43 +309,7 @@
 			}
 		},
 		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Theater Play Premiere",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
+			"account_id": "28",
 			"channels": {
 				"set": [
 					"1"
@@ -733,7 +319,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-05-24T07:00:00.000Z",
+					"start_date_at": "2024-09-27T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -741,7 +327,7 @@
 			}
 		},
 		{
-			"account_id": "13",
+			"account_id": "28",
 			"channels": {
 				"set": [
 					"1"
@@ -751,7 +337,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-02-01T07:00:00.000Z",
+					"start_date_at": "2025-06-22T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -760,132 +346,6 @@
 		},
 		{
 			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cultural Heritage Celebration",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cultural Heritage Celebration",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Photography Contest Awards",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-11-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-07-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-09-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
 			"channels": {
 				"set": [
 					"1"
@@ -895,367 +355,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-01-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Live Band Concert",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-08-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-12-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Gardening Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-09-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Live Band Concert",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-01T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Job Fair Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-07-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Language Exchange Meetup",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Language Exchange Meetup",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Poetry Slam Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-10-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-11-02T07:00:00.000Z",
+					"start_date_at": "2025-02-16T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -1273,7 +373,25 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-01-16T07:00:00.000Z",
+					"start_date_at": "2026-11-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Comedy Night Live",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-23T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -1291,7 +409,61 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-04-09T07:00:00.000Z",
+					"start_date_at": "2025-02-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Comedy Night Live",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-09-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-10-22T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -1305,11 +477,11 @@
 					"1"
 				]
 			},
-			"title": "Public Speaking Workshop",
+			"title": "Science Fair Showcase",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-09-14T07:00:00.000Z",
+					"start_date_at": "2026-06-12T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -1323,11 +495,83 @@
 					"1"
 				]
 			},
-			"title": "Volunteer Appreciation Day",
+			"title": "Annual Charity Gala",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-07-05T07:00:00.000Z",
+					"start_date_at": "2024-02-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Charity Fun Run",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-07T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -1345,7 +589,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-01-07T07:00:00.000Z",
+					"start_date_at": "2026-07-27T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -1353,17 +597,53 @@
 			}
 		},
 		{
-			"account_id": "7",
+			"account_id": "36",
 			"channels": {
 				"set": [
 					"1"
 				]
 			},
-			"title": "Language Exchange Meetup",
+			"title": "Yoga Retreat Weekend",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-06-25T07:00:00.000Z",
+					"start_date_at": "2026-10-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Networking Mixer Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-05-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Startup Pitch Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-11-11T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -1377,11 +657,101 @@
 					"1"
 				]
 			},
-			"title": "Pet Adoption Event",
+			"title": "Photography Contest Awards",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-12-15T07:00:00.000Z",
+					"start_date_at": "2026-12-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Theater Play Premiere",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-09-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Photography Contest Awards",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-02-01T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -1399,7 +769,637 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-06-02T07:00:00.000Z",
+					"start_date_at": "2024-09-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-05-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Photography Contest Awards",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-09-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-12-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Art Exhibition Opening",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-01-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Live Band Concert",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-03-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Art Exhibition Opening",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gardening Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Live Band Concert",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-01T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-01-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Job Fair Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-09-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-04-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-08-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-07-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Poetry Slam Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-10-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Business Leadership Conference",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-09-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-01-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-12-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-06-02T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -1417,7 +1417,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-02-28T07:00:00.000Z",
+					"start_date_at": "2024-02-28T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -1435,7 +1435,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-06-18T07:00:00.000Z",
+					"start_date_at": "2024-06-18T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -1450,6 +1450,5316 @@
 				]
 			},
 			"title": "Photography Contest Awards",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-02-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-31T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-10-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Art Exhibition Opening",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-09-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-06-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Wine Tasting Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Environmental Awareness Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-12-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-12-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-08-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-07-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-05-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-03-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Live Band Concert",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-08-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-08-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Charity Fun Run",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-31T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-08-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Charity Fun Run",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-03-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Annual Charity Gala",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-08-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Art Exhibition Opening",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-04-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-01T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-05-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sports Tournament Finals",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-10-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fashion Show Runway",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Networking Mixer Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-10-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-08-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-07-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sports Tournament Finals",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gaming Convention",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-02-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Environmental Awareness Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fitness Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-31T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-12-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sports Tournament Finals",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-05-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Startup Pitch Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-10-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Poetry Slam Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sports Tournament Finals",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-12-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Job Fair Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sports Tournament Finals",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fitness Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Poetry Slam Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-06-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Annual Charity Gala",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Poetry Slam Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2023-12-31T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-05-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Poetry Slam Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-11-01T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fashion Show Runway",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-05-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sports Tournament Finals",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-12-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-04-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Theater Play Premiere",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-08-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Poetry Slam Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Food Truck Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Job Fair Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-06-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Charity Fun Run",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-02-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-12-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-07-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Business Leadership Conference",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Art Exhibition Opening",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Wine Tasting Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-10-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-03-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-10-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-09-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Charity Fun Run",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-09-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Annual Charity Gala",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-05-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Marathon Race Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Charity Fun Run",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Startup Pitch Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-06-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-03-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Comedy Night Live",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Marathon Race Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Networking Mixer Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Wine Tasting Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-10-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-01-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gaming Convention",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-30T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Environmental Awareness Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Job Fair Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-10-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-12-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-06-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Holiday Craft Market",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-11-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-06-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Comedy Night Live",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-02-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-02-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Food Truck Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Marathon Race Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gardening Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Wine Tasting Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-07-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-07-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-03-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Wine Tasting Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-01-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-09-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-10-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Startup Pitch Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-02-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Job Fair Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Theater Play Premiere",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gardening Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-08-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-12-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-10-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Community Health Fair",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-06-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Photography Contest Awards",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Art Exhibition Opening",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Annual Charity Gala",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-10-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Theater Play Premiere",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-07-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Networking Mixer Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Marathon Race Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Business Leadership Conference",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-06-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Community Health Fair",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gaming Convention",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-31T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-04-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fashion Show Runway",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-10-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Startup Pitch Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-06-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Art Exhibition Opening",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-01-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-07-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-07-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-10-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Comedy Night Live",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-04-30T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-12-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-04-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gaming Convention",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-03-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Live Band Concert",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-07-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Marathon Race Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Photography Contest Awards",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fashion Show Runway",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Environmental Awareness Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-01-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Business Leadership Conference",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-04-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Holiday Craft Market",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Community Health Fair",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-09-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-01-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-07-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-10-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Food Truck Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-01T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Marathon Race Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-03-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Comedy Night Live",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Job Fair Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-10-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Wine Tasting Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-09-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-01-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Networking Mixer Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-01-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Theater Play Premiere",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-03-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-09-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-11-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Startup Pitch Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gardening Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-07-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Community Health Fair",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-08-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Annual Charity Gala",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-02-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Live Band Concert",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-03-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fashion Show Runway",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Business Leadership Conference",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Holiday Craft Market",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Marathon Race Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-03-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-30T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-10-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Holiday Craft Market",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-01-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-01T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-12-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Environmental Awareness Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-01-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
@@ -1471,25 +6781,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-07-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Language Exchange Meetup",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-06-13T07:00:00.000Z",
+					"start_date_at": "2026-09-09T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -1503,371 +6795,11 @@
 					"1"
 				]
 			},
-			"title": "Interior Design Workshop",
+			"title": "Photography Contest Awards",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-12-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-03-31T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Language Exchange Meetup",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-10-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Wine Tasting Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-12-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Environmental Awareness Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-06-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-01-11T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Science Fair Showcase",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Live Band Concert",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-22T07:00:00.000Z",
+					"start_date_at": "2024-04-18T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -1885,1213 +6817,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-08-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Charity Fun Run",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-31T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Charity Fun Run",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Annual Charity Gala",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-02-01T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Language Exchange Meetup",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cultural Heritage Celebration",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-02-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sports Tournament Finals",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-10-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fashion Show Runway",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Networking Mixer Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-10-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-05-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sports Tournament Finals",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Gaming Convention",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Environmental Awareness Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-02-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fitness Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-12-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-09-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Meditation Session",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-01-31T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Interior Design Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sports Tournament Finals",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Startup Pitch Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-10-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-09-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Poetry Slam Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-07-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sports Tournament Finals",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-09-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-02-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-02-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Job Fair Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-12-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sports Tournament Finals",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-05-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fitness Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-11-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Poetry Slam Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-07-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-05-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Interior Design Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Annual Charity Gala",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-08-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-12-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-07-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-02-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Poetry Slam Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-31T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-01-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Poetry Slam Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-01T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-03-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fashion Show Runway",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cultural Heritage Celebration",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-09-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sports Tournament Finals",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-05-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Theater Play Premiere",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-15T07:00:00.000Z",
+					"start_date_at": "2024-11-04T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -3106,114 +6832,6 @@
 				]
 			},
 			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-08-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Poetry Slam Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-05-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Food Truck Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-11T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Job Fair Expo",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
@@ -3225,528 +6843,6 @@
 			}
 		},
 		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Charity Fun Run",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Business Leadership Conference",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-11-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-12-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Interior Design Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-09-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Wine Tasting Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-10-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-10-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-11-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Charity Fun Run",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-11-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Annual Charity Gala",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Marathon Race Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-01-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Charity Fun Run",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Startup Pitch Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
 			"account_id": "7",
 			"channels": {
 				"set": [
@@ -3757,43 +6853,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-11-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-15T07:00:00.000Z",
+					"start_date_at": "2024-07-03T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -3811,151 +6871,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-06-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Comedy Night Live",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Marathon Race Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-03-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Networking Mixer Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-08-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Wine Tasting Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-10-26T07:00:00.000Z",
+					"start_date_at": "2024-05-25T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -3964,366 +6880,6 @@
 		},
 		{
 			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Language Exchange Meetup",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-01-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Gaming Convention",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-30T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Environmental Awareness Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-01-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-04-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Job Fair Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-10-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-07-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Meditation Session",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Holiday Craft Market",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Science Fair Showcase",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-07-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Comedy Night Live",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
 			"channels": {
 				"set": [
 					"1"
@@ -4333,709 +6889,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-07-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Food Truck Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-11T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Marathon Race Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-03-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Gardening Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-07-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Wine Tasting Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-02-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-09-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Science Fair Showcase",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-07-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-04-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Wine Tasting Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-05-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-11-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Mental Health Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-04-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-10-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Startup Pitch Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Meditation Session",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-11-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Job Fair Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-09-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Theater Play Premiere",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-07-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Gardening Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Science Fair Showcase",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-10-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Community Health Fair",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-04-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Interior Design Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Photography Contest Awards",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-06-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-01-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Annual Charity Gala",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-15T07:00:00.000Z",
+					"start_date_at": "2026-06-18T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5050,1752 +6904,6 @@
 				]
 			},
 			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-10-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Theater Play Premiere",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-03-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-08-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Networking Mixer Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-05-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-03-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Mental Health Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-07-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Marathon Race Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-02-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Business Leadership Conference",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-04-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Science Fair Showcase",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-09-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Community Health Fair",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-12-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Gaming Convention",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-01-31T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Meditation Session",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-08-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cultural Heritage Celebration",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fashion Show Runway",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-10-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Startup Pitch Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Interior Design Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Meditation Session",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-10-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-08-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Comedy Night Live",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-30T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Gaming Convention",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Live Band Concert",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-11-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Mental Health Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-12-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-04-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Marathon Race Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Photography Contest Awards",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fashion Show Runway",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-09-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Environmental Awareness Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-03-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Mental Health Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Interior Design Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-06-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Business Leadership Conference",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Holiday Craft Market",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-08-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-02-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Community Health Fair",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-07-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-10-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Food Truck Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-12-01T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Marathon Race Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-11-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Comedy Night Live",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-11-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Language Exchange Meetup",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-05-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Job Fair Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-07-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-12-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-03-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-10-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-11-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Wine Tasting Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Science Fair Showcase",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Networking Mixer Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Theater Play Premiere",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-07-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-11T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Meditation Session",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-11T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Startup Pitch Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-01-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Gardening Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Community Health Fair",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-02-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-06-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Meditation Session",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Mental Health Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Annual Charity Gala",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Live Band Concert",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fashion Show Runway",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Business Leadership Conference",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-11-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-02-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Holiday Craft Market",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-01-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Marathon Race Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-09-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-11-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-30T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Science Fair Showcase",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-10-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Holiday Craft Market",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-01-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-01T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-12-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Environmental Awareness Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-01-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Meditation Session",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-03-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-09-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Photography Contest Awards",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
@@ -6807,114 +6915,6 @@
 			}
 		},
 		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cultural Heritage Celebration",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-06-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
 			"account_id": "7",
 			"channels": {
 				"set": [
@@ -6925,7 +6925,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-11-27T07:00:00.000Z",
+					"start_date_at": "2024-11-27T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6943,7 +6943,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-04-20T07:00:00.000Z",
+					"start_date_at": "2026-04-20T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6961,7 +6961,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-05-08T07:00:00.000Z",
+					"start_date_at": "2024-05-08T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6979,7 +6979,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-10-16T07:00:00.000Z",
+					"start_date_at": "2026-10-16T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6997,7 +6997,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-12-24T07:00:00.000Z",
+					"start_date_at": "2026-12-24T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7015,7 +7015,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-07-26T07:00:00.000Z",
+					"start_date_at": "2024-07-26T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7033,7 +7033,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-03-28T07:00:00.000Z",
+					"start_date_at": "2026-03-28T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7051,7 +7051,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-01-17T07:00:00.000Z",
+					"start_date_at": "2026-01-17T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7069,7 +7069,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-07-22T07:00:00.000Z",
+					"start_date_at": "2024-07-22T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7087,7 +7087,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-12-11T07:00:00.000Z",
+					"start_date_at": "2026-12-11T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7105,7 +7105,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-03-24T07:00:00.000Z",
+					"start_date_at": "2026-03-24T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7120,42 +7120,6 @@
 				]
 			},
 			"title": "Live Band Concert",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2027-05-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Comedy Night Live",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Pet Adoption Event",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
@@ -7173,11 +7137,47 @@
 					"1"
 				]
 			},
+			"title": "Comedy Night Live",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-05-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Craft Beer Festival",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-03-11T07:00:00.000Z",
+					"start_date_at": "2024-03-11T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7195,7 +7195,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-02-13T07:00:00.000Z",
+					"start_date_at": "2026-02-13T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7213,7 +7213,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-12-20T07:00:00.000Z",
+					"start_date_at": "2025-12-20T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7231,7 +7231,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-03-21T07:00:00.000Z",
+					"start_date_at": "2024-03-21T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7249,7 +7249,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-03-10T07:00:00.000Z",
+					"start_date_at": "2024-03-10T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7267,7 +7267,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-12-08T07:00:00.000Z",
+					"start_date_at": "2025-12-08T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7285,7 +7285,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-07-05T07:00:00.000Z",
+					"start_date_at": "2025-07-05T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7303,7 +7303,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-10-06T07:00:00.000Z",
+					"start_date_at": "2024-10-06T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7321,7 +7321,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-07-24T07:00:00.000Z",
+					"start_date_at": "2025-07-24T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7339,7 +7339,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-04-18T07:00:00.000Z",
+					"start_date_at": "2026-04-18T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7357,7 +7357,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-12-13T07:00:00.000Z",
+					"start_date_at": "2025-12-13T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7375,7 +7375,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-04-20T07:00:00.000Z",
+					"start_date_at": "2026-04-20T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7393,7 +7393,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-11-09T07:00:00.000Z",
+					"start_date_at": "2026-11-09T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7411,7 +7411,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-06-07T07:00:00.000Z",
+					"start_date_at": "2025-06-07T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7429,7 +7429,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-05-09T07:00:00.000Z",
+					"start_date_at": "2026-05-09T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7447,7 +7447,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-03-19T07:00:00.000Z",
+					"start_date_at": "2026-03-19T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7465,7 +7465,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-02-23T07:00:00.000Z",
+					"start_date_at": "2025-02-23T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7483,7 +7483,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-02-13T07:00:00.000Z",
+					"start_date_at": "2024-02-13T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7501,7 +7501,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-05-03T07:00:00.000Z",
+					"start_date_at": "2024-05-03T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7519,7 +7519,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-09-03T07:00:00.000Z",
+					"start_date_at": "2026-09-03T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7537,7 +7537,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-03-01T07:00:00.000Z",
+					"start_date_at": "2024-03-01T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7555,7 +7555,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-06-10T07:00:00.000Z",
+					"start_date_at": "2026-06-10T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7573,7 +7573,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-09-27T07:00:00.000Z",
+					"start_date_at": "2026-09-27T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7591,7 +7591,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-12-03T07:00:00.000Z",
+					"start_date_at": "2024-12-03T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7609,7 +7609,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-12-03T07:00:00.000Z",
+					"start_date_at": "2025-12-03T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7627,7 +7627,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-07-04T07:00:00.000Z",
+					"start_date_at": "2024-07-04T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7645,7 +7645,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-08-04T07:00:00.000Z",
+					"start_date_at": "2024-08-04T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7663,7 +7663,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-12-25T07:00:00.000Z",
+					"start_date_at": "2026-12-25T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7681,7 +7681,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-03-14T07:00:00.000Z",
+					"start_date_at": "2026-03-14T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7699,7 +7699,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-07-02T07:00:00.000Z",
+					"start_date_at": "2025-07-02T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7717,7 +7717,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-09-18T07:00:00.000Z",
+					"start_date_at": "2026-09-18T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7735,7 +7735,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-07-26T07:00:00.000Z",
+					"start_date_at": "2025-07-26T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7753,7 +7753,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-02-15T07:00:00.000Z",
+					"start_date_at": "2025-02-15T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7771,7 +7771,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-07-22T07:00:00.000Z",
+					"start_date_at": "2026-07-22T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7789,7 +7789,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-03-09T07:00:00.000Z",
+					"start_date_at": "2024-03-09T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7807,7 +7807,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-07-11T07:00:00.000Z",
+					"start_date_at": "2024-07-11T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7825,7 +7825,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-01-01T07:00:00.000Z",
+					"start_date_at": "2024-01-01T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7843,7 +7843,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-04-16T07:00:00.000Z",
+					"start_date_at": "2024-04-16T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7861,7 +7861,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-10-05T07:00:00.000Z",
+					"start_date_at": "2025-10-05T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7879,7 +7879,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-03-03T07:00:00.000Z",
+					"start_date_at": "2025-03-03T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7897,7 +7897,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-11-16T07:00:00.000Z",
+					"start_date_at": "2024-11-16T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7915,7 +7915,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-04-14T07:00:00.000Z",
+					"start_date_at": "2026-04-14T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7933,7 +7933,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-06-30T07:00:00.000Z",
+					"start_date_at": "2024-06-30T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7951,7 +7951,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-09-13T07:00:00.000Z",
+					"start_date_at": "2025-09-13T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7969,7 +7969,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-03-27T07:00:00.000Z",
+					"start_date_at": "2026-03-27T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -7987,7 +7987,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-01-24T07:00:00.000Z",
+					"start_date_at": "2026-01-24T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8005,7 +8005,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-03-31T07:00:00.000Z",
+					"start_date_at": "2026-03-31T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8023,7 +8023,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-11-20T07:00:00.000Z",
+					"start_date_at": "2025-11-20T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8041,7 +8041,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-07-17T07:00:00.000Z",
+					"start_date_at": "2025-07-17T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8059,7 +8059,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-03-17T07:00:00.000Z",
+					"start_date_at": "2026-03-17T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8077,7 +8077,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-06-15T07:00:00.000Z",
+					"start_date_at": "2025-06-15T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8095,7 +8095,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-08-17T07:00:00.000Z",
+					"start_date_at": "2026-08-17T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8113,7 +8113,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-09-23T07:00:00.000Z",
+					"start_date_at": "2024-09-23T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8131,7 +8131,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-08-18T07:00:00.000Z",
+					"start_date_at": "2025-08-18T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8149,7 +8149,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-08-18T07:00:00.000Z",
+					"start_date_at": "2025-08-18T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8167,7 +8167,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-07-23T07:00:00.000Z",
+					"start_date_at": "2025-07-23T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8185,7 +8185,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-12-09T07:00:00.000Z",
+					"start_date_at": "2025-12-09T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8203,7 +8203,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-08-17T07:00:00.000Z",
+					"start_date_at": "2025-08-17T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8221,7 +8221,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-08-08T07:00:00.000Z",
+					"start_date_at": "2024-08-08T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8239,7 +8239,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-02-07T07:00:00.000Z",
+					"start_date_at": "2025-02-07T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8257,7 +8257,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-07-04T07:00:00.000Z",
+					"start_date_at": "2026-07-04T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8275,7 +8275,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-02-15T07:00:00.000Z",
+					"start_date_at": "2025-02-15T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8293,7 +8293,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-02-17T07:00:00.000Z",
+					"start_date_at": "2026-02-17T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8311,7 +8311,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-06-19T07:00:00.000Z",
+					"start_date_at": "2026-06-19T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8329,7 +8329,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-04-10T07:00:00.000Z",
+					"start_date_at": "2025-04-10T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8347,7 +8347,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-11-22T07:00:00.000Z",
+					"start_date_at": "2026-11-22T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8365,7 +8365,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-06-13T07:00:00.000Z",
+					"start_date_at": "2026-06-13T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8383,7 +8383,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-06-11T07:00:00.000Z",
+					"start_date_at": "2026-06-11T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8401,7 +8401,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-11-01T07:00:00.000Z",
+					"start_date_at": "2024-11-01T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8419,7 +8419,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-04-11T07:00:00.000Z",
+					"start_date_at": "2025-04-11T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8437,7 +8437,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-10-05T07:00:00.000Z",
+					"start_date_at": "2025-10-05T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8455,7 +8455,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-12-17T07:00:00.000Z",
+					"start_date_at": "2025-12-17T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8473,7 +8473,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-08-01T07:00:00.000Z",
+					"start_date_at": "2025-08-01T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8491,7 +8491,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-09-03T07:00:00.000Z",
+					"start_date_at": "2026-09-03T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8509,7 +8509,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-05-05T07:00:00.000Z",
+					"start_date_at": "2025-05-05T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8527,7 +8527,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-07-15T07:00:00.000Z",
+					"start_date_at": "2024-07-15T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8545,7 +8545,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-07-21T07:00:00.000Z",
+					"start_date_at": "2024-07-21T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8563,7 +8563,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-12-08T07:00:00.000Z",
+					"start_date_at": "2025-12-08T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8581,7 +8581,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-02-10T07:00:00.000Z",
+					"start_date_at": "2025-02-10T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8599,7 +8599,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-12-02T07:00:00.000Z",
+					"start_date_at": "2026-12-02T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8617,7 +8617,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-01-31T07:00:00.000Z",
+					"start_date_at": "2024-01-31T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8635,7 +8635,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-03-20T07:00:00.000Z",
+					"start_date_at": "2025-03-20T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8653,7 +8653,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-10-24T07:00:00.000Z",
+					"start_date_at": "2026-10-24T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8671,7 +8671,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-03-31T07:00:00.000Z",
+					"start_date_at": "2024-03-31T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8689,7 +8689,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-10-02T07:00:00.000Z",
+					"start_date_at": "2025-10-02T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8707,7 +8707,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-06-09T07:00:00.000Z",
+					"start_date_at": "2026-06-09T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8725,7 +8725,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-01-26T07:00:00.000Z",
+					"start_date_at": "2026-01-26T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8743,7 +8743,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-06-17T07:00:00.000Z",
+					"start_date_at": "2025-06-17T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8761,7 +8761,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-04-24T07:00:00.000Z",
+					"start_date_at": "2024-04-24T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8779,7 +8779,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-10-11T07:00:00.000Z",
+					"start_date_at": "2025-10-11T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8797,7 +8797,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-02-15T07:00:00.000Z",
+					"start_date_at": "2026-02-15T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8815,7 +8815,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-11-17T07:00:00.000Z",
+					"start_date_at": "2026-11-17T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8833,7 +8833,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-05-19T07:00:00.000Z",
+					"start_date_at": "2025-05-19T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8851,7 +8851,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-09-26T07:00:00.000Z",
+					"start_date_at": "2024-09-26T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8869,7 +8869,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-06-19T07:00:00.000Z",
+					"start_date_at": "2024-06-19T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8887,7 +8887,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-04-15T07:00:00.000Z",
+					"start_date_at": "2024-04-15T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8905,7 +8905,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-11-24T07:00:00.000Z",
+					"start_date_at": "2024-11-24T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8923,7 +8923,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-02-03T07:00:00.000Z",
+					"start_date_at": "2024-02-03T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8941,7 +8941,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2027-01-26T07:00:00.000Z",
+					"start_date_at": "2026-01-26T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8959,7 +8959,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-10-13T07:00:00.000Z",
+					"start_date_at": "2025-10-13T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8977,7 +8977,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-01-28T07:00:00.000Z",
+					"start_date_at": "2024-01-28T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8995,7 +8995,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-06-30T07:00:00.000Z",
+					"start_date_at": "2024-06-30T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"

--- a/data/leisure_events_automated.json
+++ b/data/leisure_events_automated.json
@@ -13,7 +13,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-07-14T07:00:00.000Z",
+					"start_date_at": "2025-07-14T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -31,7 +31,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-09-02T07:00:00.000Z",
+					"start_date_at": "2026-09-02T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -49,7 +49,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-01-13T07:00:00.000Z",
+					"start_date_at": "2025-01-13T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -67,7 +67,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-01-12T07:00:00.000Z",
+					"start_date_at": "2025-01-12T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -85,7 +85,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-05-17T07:00:00.000Z",
+					"start_date_at": "2027-05-17T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -103,7 +103,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-07-17T07:00:00.000Z",
+					"start_date_at": "2025-07-17T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -121,7 +121,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-11-01T07:00:00.000Z",
+					"start_date_at": "2026-11-01T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -139,7 +139,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-10-04T07:00:00.000Z",
+					"start_date_at": "2025-10-04T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -157,7 +157,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-02-20T07:00:00.000Z",
+					"start_date_at": "2026-02-20T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -175,7 +175,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-05-06T07:00:00.000Z",
+					"start_date_at": "2025-05-06T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -193,7 +193,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-08-19T07:00:00.000Z",
+					"start_date_at": "2025-08-19T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -211,7 +211,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-09-11T07:00:00.000Z",
+					"start_date_at": "2025-09-11T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -229,7 +229,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-01-18T07:00:00.000Z",
+					"start_date_at": "2026-01-18T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -247,7 +247,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-08-23T07:00:00.000Z",
+					"start_date_at": "2025-08-23T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -265,7 +265,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-10-22T07:00:00.000Z",
+					"start_date_at": "2026-10-22T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -283,7 +283,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-06-20T07:00:00.000Z",
+					"start_date_at": "2027-06-20T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -301,7 +301,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-12-24T07:00:00.000Z",
+					"start_date_at": "2026-12-24T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -319,7 +319,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-09-27T07:00:00.000Z",
+					"start_date_at": "2025-09-27T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -337,7 +337,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-06-22T07:00:00.000Z",
+					"start_date_at": "2026-06-22T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -355,7 +355,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-02-16T07:00:00.000Z",
+					"start_date_at": "2026-02-16T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -373,7 +373,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-11-19T07:00:00.000Z",
+					"start_date_at": "2027-11-19T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -388,294 +388,6 @@
 				]
 			},
 			"title": "Comedy Night Live",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Comedy Night Live",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Science Fair Showcase",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Annual Charity Gala",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-02-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Charity Fun Run",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-10-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Networking Mixer Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-05-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Startup Pitch Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-11-11T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Photography Contest Awards",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Magic Show Spectacular",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
@@ -687,600 +399,6 @@
 			}
 		},
 		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Theater Play Premiere",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Photography Contest Awards",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-02-01T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cultural Heritage Celebration",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cultural Heritage Celebration",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-05-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Photography Contest Awards",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-11-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-01-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Live Band Concert",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Gardening Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Live Band Concert",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-01T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-01-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Job Fair Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Language Exchange Meetup",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-04-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Language Exchange Meetup",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Poetry Slam Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Business Leadership Conference",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
 			"account_id": "13",
 			"channels": {
 				"set": [
@@ -1291,61 +409,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-04-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-01-07T07:00:00.000Z",
+					"start_date_at": "2026-02-22T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -1359,7 +423,7 @@
 					"1"
 				]
 			},
-			"title": "Language Exchange Meetup",
+			"title": "Book Launch Party",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
@@ -1377,11 +441,11 @@
 					"1"
 				]
 			},
-			"title": "Pet Adoption Event",
+			"title": "Comedy Night Live",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-12-15T07:00:00.000Z",
+					"start_date_at": "2025-09-23T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -1395,11 +459,65 @@
 					"1"
 				]
 			},
-			"title": "Cultural Heritage Celebration",
+			"title": "Sustainable Living Seminar",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-06-02T07:00:00.000Z",
+					"start_date_at": "2025-10-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Annual Charity Gala",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-08T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -1413,11 +531,11 @@
 					"1"
 				]
 			},
-			"title": "Networking Mixer Event",
+			"title": "Dance Performance Recital",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-02-28T07:00:00.000Z",
+					"start_date_at": "2026-09-03T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -1431,11 +549,29 @@
 					"1"
 				]
 			},
-			"title": "Fundraising Dinner",
+			"title": "Yoga Retreat Weekend",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-06-18T07:00:00.000Z",
+					"start_date_at": "2026-08-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Charity Fun Run",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-07T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -1444,6 +580,78 @@
 		},
 		{
 			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-10-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Networking Mixer Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Startup Pitch Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
 			"channels": {
 				"set": [
 					"1"
@@ -1453,43 +661,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-03-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Language Exchange Meetup",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-13T07:00:00.000Z",
+					"start_date_at": "2027-12-25T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -1498,222 +670,6 @@
 		},
 		{
 			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Interior Design Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-02-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-31T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Language Exchange Meetup",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-06-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Wine Tasting Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Environmental Awareness Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
 			"channels": {
 				"set": [
 					"1"
@@ -1723,1825 +679,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-08-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-11T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-05-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Science Fair Showcase",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Live Band Concert",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Charity Fun Run",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-31T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Charity Fun Run",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Annual Charity Gala",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-04-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-01T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Language Exchange Meetup",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-05-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cultural Heritage Celebration",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sports Tournament Finals",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-10-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fashion Show Runway",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Networking Mixer Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sports Tournament Finals",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Gaming Convention",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-02-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Environmental Awareness Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fitness Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Meditation Session",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-31T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Interior Design Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sports Tournament Finals",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-05-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Startup Pitch Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Poetry Slam Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sports Tournament Finals",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Job Fair Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sports Tournament Finals",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fitness Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Poetry Slam Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Interior Design Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-06-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Annual Charity Gala",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Poetry Slam Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2023-12-31T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-05-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Poetry Slam Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-11-01T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fashion Show Runway",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-05-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cultural Heritage Celebration",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sports Tournament Finals",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-04-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Theater Play Premiere",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Poetry Slam Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Food Truck Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-11T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Job Fair Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-06-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Charity Fun Run",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-02-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Business Leadership Conference",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Interior Design Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Wine Tasting Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-10-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-27T07:00:00.000Z",
+					"start_date_at": "2027-09-23T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -3556,1644 +694,6 @@
 				]
 			},
 			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-11-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Charity Fun Run",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Annual Charity Gala",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-05-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Marathon Race Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Charity Fun Run",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Startup Pitch Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-06-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Comedy Night Live",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Marathon Race Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Networking Mixer Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Wine Tasting Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Language Exchange Meetup",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-01-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Gaming Convention",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-30T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Environmental Awareness Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Job Fair Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Meditation Session",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-06-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Holiday Craft Market",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-11-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-06-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Science Fair Showcase",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Comedy Night Live",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-02-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-02-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cultural Heritage Celebration",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Food Truck Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-11T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Marathon Race Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Gardening Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Wine Tasting Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Science Fair Showcase",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Wine Tasting Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Mental Health Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-01-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Startup Pitch Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-02-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Meditation Session",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-11-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Job Fair Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Theater Play Premiere",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Gardening Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Science Fair Showcase",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Community Health Fair",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Interior Design Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-06-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Photography Contest Awards",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Annual Charity Gala",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-10-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Theater Play Premiere",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Networking Mixer Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Mental Health Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Marathon Race Day",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
@@ -5211,29 +711,11 @@
 					"1"
 				]
 			},
-			"title": "Business Leadership Conference",
+			"title": "Theater Play Premiere",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-04-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-06-25T07:00:00.000Z",
+					"start_date_at": "2025-09-15T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5247,65 +729,11 @@
 					"1"
 				]
 			},
-			"title": "Science Fair Showcase",
+			"title": "Photography Contest Awards",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-09-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Community Health Fair",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Gaming Convention",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-31T07:00:00.000Z",
+					"start_date_at": "2026-05-24T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5319,11 +747,11 @@
 					"1"
 				]
 			},
-			"title": "Meditation Session",
+			"title": "Volunteer Appreciation Day",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-08-07T07:00:00.000Z",
+					"start_date_at": "2025-02-01T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5331,7 +759,7 @@
 			}
 		},
 		{
-			"account_id": "7",
+			"account_id": "28",
 			"channels": {
 				"set": [
 					"1"
@@ -5341,7 +769,25 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-05-22T07:00:00.000Z",
+					"start_date_at": "2025-09-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-28T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5355,11 +801,11 @@
 					"1"
 				]
 			},
-			"title": "Craft Beer Festival",
+			"title": "Photography Contest Awards",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-04-02T07:00:00.000Z",
+					"start_date_at": "2025-09-05T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5373,29 +819,11 @@
 					"1"
 				]
 			},
-			"title": "Fashion Show Runway",
+			"title": "Robotics Competition",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-10-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Startup Pitch Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-10T07:00:00.000Z",
+					"start_date_at": "2027-11-20T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5409,11 +837,11 @@
 					"1"
 				]
 			},
-			"title": "Interior Design Workshop",
+			"title": "Public Speaking Workshop",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-05-24T07:00:00.000Z",
+					"start_date_at": "2025-12-28T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5427,11 +855,11 @@
 					"1"
 				]
 			},
-			"title": "Pet Adoption Event",
+			"title": "Sustainable Living Seminar",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-06-07T07:00:00.000Z",
+					"start_date_at": "2027-07-04T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5439,7 +867,7 @@
 			}
 		},
 		{
-			"account_id": "36",
+			"account_id": "7",
 			"channels": {
 				"set": [
 					"1"
@@ -5449,7 +877,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-01-10T07:00:00.000Z",
+					"start_date_at": "2027-09-26T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5457,179 +885,17 @@
 			}
 		},
 		{
-			"account_id": "28",
+			"account_id": "7",
 			"channels": {
 				"set": [
 					"1"
 				]
 			},
-			"title": "Fundraising Dinner",
+			"title": "Historical Lecture Series",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-07-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Meditation Session",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Comedy Night Live",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-04-30T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-04-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Gaming Convention",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-25T07:00:00.000Z",
+					"start_date_at": "2025-01-23T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5647,7 +913,61 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-11-06T07:00:00.000Z",
+					"start_date_at": "2027-08-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-08T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5661,11 +981,11 @@
 					"1"
 				]
 			},
-			"title": "Mental Health Seminar",
+			"title": "Art Exhibition Opening",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-12-26T07:00:00.000Z",
+					"start_date_at": "2026-04-19T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5679,11 +999,11 @@
 					"1"
 				]
 			},
-			"title": "Dance Performance Recital",
+			"title": "Gardening Workshop",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-04-25T07:00:00.000Z",
+					"start_date_at": "2027-09-10T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5697,11 +1017,11 @@
 					"1"
 				]
 			},
-			"title": "Yoga Retreat Weekend",
+			"title": "Live Band Concert",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-07-10T07:00:00.000Z",
+					"start_date_at": "2026-12-01T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5709,17 +1029,35 @@
 			}
 		},
 		{
-			"account_id": "36",
+			"account_id": "13",
 			"channels": {
 				"set": [
 					"1"
 				]
 			},
-			"title": "Marathon Race Day",
+			"title": "Music Festival Extravaganza",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-09-07T07:00:00.000Z",
+					"start_date_at": "2026-05-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-26T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5733,65 +1071,11 @@
 					"1"
 				]
 			},
-			"title": "Photography Contest Awards",
+			"title": "Public Speaking Workshop",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-07-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fashion Show Runway",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Environmental Awareness Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Mental Health Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-01-24T07:00:00.000Z",
+					"start_date_at": "2026-04-03T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5805,11 +1089,173 @@
 					"1"
 				]
 			},
-			"title": "Interior Design Workshop",
+			"title": "Travel Expo",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-06-21T07:00:00.000Z",
+					"start_date_at": "2026-01-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Job Fair Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Poetry Slam Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-10-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-02T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5827,7 +1273,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-08-26T07:00:00.000Z",
+					"start_date_at": "2027-01-16T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5841,83 +1287,11 @@
 					"1"
 				]
 			},
-			"title": "Historical Lecture Series",
+			"title": "Tech Innovation Summit",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-04-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Holiday Craft Market",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Community Health Fair",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-21T07:00:00.000Z",
+					"start_date_at": "2027-04-09T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5931,11 +1305,11 @@
 					"1"
 				]
 			},
-			"title": "Astronomy Night",
+			"title": "Public Speaking Workshop",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-01-06T07:00:00.000Z",
+					"start_date_at": "2025-09-14T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5949,11 +1323,227 @@
 					"1"
 				]
 			},
-			"title": "Astronomy Night",
+			"title": "Volunteer Appreciation Day",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-07-12T07:00:00.000Z",
+					"start_date_at": "2027-07-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Networking Mixer Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Photography Contest Awards",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-31T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5971,7 +1561,187 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-10-08T07:00:00.000Z",
+					"start_date_at": "2026-07-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-10-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Art Exhibition Opening",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Wine Tasting Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Environmental Awareness Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-17T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5985,7 +1755,259 @@
 					"1"
 				]
 			},
-			"title": "Food Truck Festival",
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Live Band Concert",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Charity Fun Run",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-31T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Charity Fun Run",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Annual Charity Gala",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
@@ -6003,47 +2025,11 @@
 					"1"
 				]
 			},
-			"title": "Virtual Reality Experience",
+			"title": "Art Exhibition Opening",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-12-01T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Marathon Race Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-08T07:00:00.000Z",
+					"start_date_at": "2025-04-08T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6052,114 +2038,6 @@
 		},
 		{
 			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Comedy Night Live",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Language Exchange Meetup",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Job Fair Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-10-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
 			"channels": {
 				"set": [
 					"1"
@@ -6169,97 +2047,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-11-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Wine Tasting Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Science Fair Showcase",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-01-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Networking Mixer Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-01-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Theater Play Premiere",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-11T07:00:00.000Z",
+					"start_date_at": "2027-02-01T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6273,101 +2061,11 @@
 					"1"
 				]
 			},
-			"title": "Public Speaking Workshop",
+			"title": "Language Exchange Meetup",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-09-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Meditation Session",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-11-11T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Startup Pitch Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Gardening Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Community Health Fair",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-07T07:00:00.000Z",
+					"start_date_at": "2025-05-21T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6381,29 +2079,11 @@
 					"1"
 				]
 			},
-			"title": "Meditation Session",
+			"title": "Robotics Competition",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-05-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-27T07:00:00.000Z",
+					"start_date_at": "2026-06-03T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6412,42 +2092,6 @@
 		},
 		{
 			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Mental Health Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Annual Charity Gala",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-02-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
 			"channels": {
 				"set": [
 					"1"
@@ -6457,7 +2101,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-03-07T07:00:00.000Z",
+					"start_date_at": "2026-06-08T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6465,17 +2109,35 @@
 			}
 		},
 		{
-			"account_id": "13",
+			"account_id": "28",
 			"channels": {
 				"set": [
 					"1"
 				]
 			},
-			"title": "Live Band Concert",
+			"title": "Cultural Heritage Celebration",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-03-12T07:00:00.000Z",
+					"start_date_at": "2027-02-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sports Tournament Finals",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-10-26T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6493,25 +2155,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-04-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Business Leadership Conference",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-08T07:00:00.000Z",
+					"start_date_at": "2026-12-09T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6525,47 +2169,11 @@
 					"1"
 				]
 			},
-			"title": "Music Festival Extravaganza",
+			"title": "Networking Mixer Event",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-02-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Holiday Craft Market",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Marathon Race Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-06T07:00:00.000Z",
+					"start_date_at": "2025-10-23T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6574,24 +2182,6 @@
 		},
 		{
 			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
 			"channels": {
 				"set": [
 					"1"
@@ -6601,7 +2191,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-09-16T07:00:00.000Z",
+					"start_date_at": "2025-08-05T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6610,96 +2200,6 @@
 		},
 		{
 			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-11-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-30T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Science Fair Showcase",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Holiday Craft Market",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-01-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-01T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
 			"channels": {
 				"set": [
 					"1"
@@ -6709,1339 +2209,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-12-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Environmental Awareness Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-01-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Meditation Session",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Photography Contest Awards",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-04-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-11-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-05-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cultural Heritage Celebration",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Mental Health Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-11-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fitness Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Wine Tasting Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-05-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Science Fair Showcase",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-10-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Holiday Craft Market",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Interior Design Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Mental Health Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sports Tournament Finals",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Networking Mixer Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-11T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Live Band Concert",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Comedy Night Live",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-05-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-11T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Science Fair Showcase",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Holiday Craft Market",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Mental Health Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Environmental Awareness Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fitness Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Charity Fun Run",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Holiday Craft Market",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-11-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Live Band Concert",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Wine Tasting Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Comedy Night Live",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-02-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-05-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Annual Charity Gala",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-01T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cultural Heritage Celebration",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Startup Pitch Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Mental Health Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Gardening Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sports Tournament Finals",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Food Truck Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Gaming Convention",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Gardening Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Annual Charity Gala",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Interior Design Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Environmental Awareness Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-11T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Environmental Awareness Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-01-01T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Job Fair Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-04-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-10-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-11-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fitness Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-06-30T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Theater Play Premiere",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Networking Mixer Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-31T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Theater Play Premiere",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-17T07:00:00.000Z",
+					"start_date_at": "2026-05-17T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8059,7 +2227,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-03-17T07:00:00.000Z",
+					"start_date_at": "2026-09-02T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8067,103 +2235,13 @@
 			}
 		},
 		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Fitness Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
+			"account_id": "7",
 			"channels": {
 				"set": [
 					"1"
 				]
 			},
 			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Language Exchange Meetup",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
@@ -8181,47 +2259,11 @@
 					"1"
 				]
 			},
-			"title": "Sustainable Living Seminar",
+			"title": "Yoga Retreat Weekend",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-12-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-08T07:00:00.000Z",
+					"start_date_at": "2027-05-24T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8235,11 +2277,11 @@
 					"1"
 				]
 			},
-			"title": "Public Speaking Workshop",
+			"title": "Sports Tournament Finals",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-02-07T07:00:00.000Z",
+					"start_date_at": "2026-12-27T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8253,11 +2295,119 @@
 					"1"
 				]
 			},
-			"title": "Children's Storytime",
+			"title": "Gaming Convention",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-07-04T07:00:00.000Z",
+					"start_date_at": "2025-02-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Environmental Awareness Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-02-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fitness Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-31T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-04T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8275,7 +2425,25 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-02-15T07:00:00.000Z",
+					"start_date_at": "2026-04-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sports Tournament Finals",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-07T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8289,11 +2457,11 @@
 					"1"
 				]
 			},
-			"title": "Meditation Session",
+			"title": "Startup Pitch Competition",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-02-17T07:00:00.000Z",
+					"start_date_at": "2025-10-14T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8307,11 +2475,119 @@
 					"1"
 				]
 			},
-			"title": "Dance Performance Recital",
+			"title": "Sustainable Living Seminar",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-06-19T07:00:00.000Z",
+					"start_date_at": "2027-09-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Poetry Slam Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sports Tournament Finals",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-02-13T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8325,11 +2601,29 @@
 					"1"
 				]
 			},
-			"title": "Theater Play Premiere",
+			"title": "Volunteer Appreciation Day",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-04-10T07:00:00.000Z",
+					"start_date_at": "2027-02-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-21T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8347,25 +2641,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-11-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-13T07:00:00.000Z",
+					"start_date_at": "2027-12-28T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8379,11 +2655,11 @@
 					"1"
 				]
 			},
-			"title": "Travel Expo",
+			"title": "Historical Lecture Series",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-06-11T07:00:00.000Z",
+					"start_date_at": "2026-02-08T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8397,11 +2673,11 @@
 					"1"
 				]
 			},
-			"title": "Public Speaking Workshop",
+			"title": "Sports Tournament Finals",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-11-01T07:00:00.000Z",
+					"start_date_at": "2026-06-28T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8410,6 +2686,24 @@
 		},
 		{
 			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
 			"channels": {
 				"set": [
 					"1"
@@ -8419,133 +2713,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-04-11T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Mental Health Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-10-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Poetry Slam Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-01T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Poetry Slam Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Holiday Craft Market",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-21T07:00:00.000Z",
+					"start_date_at": "2027-05-21T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8563,259 +2731,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-12-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Gaming Convention",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-01-31T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Poetry Slam Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-10-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Charity Fun Run",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-31T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-10-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cultural Heritage Celebration",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Networking Mixer Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-04-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Business Leadership Conference",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-10-11T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Meditation Session",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-11-17T07:00:00.000Z",
+					"start_date_at": "2026-11-20T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8829,11 +2745,47 @@
 					"1"
 				]
 			},
-			"title": "Coding Bootcamp",
+			"title": "Poetry Slam Night",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-05-19T07:00:00.000Z",
+					"start_date_at": "2027-07-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-05-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-28T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8851,61 +2803,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-09-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Theater Play Premiere",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-06-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Cultural Heritage Celebration",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-04-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-11-24T07:00:00.000Z",
+					"start_date_at": "2027-08-23T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8919,29 +2817,11 @@
 					"1"
 				]
 			},
-			"title": "Fitness Bootcamp",
+			"title": "Fundraising Dinner",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-02-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"channels": {
-				"set": [
-					"1"
-				]
-			},
-			"title": "Holiday Craft Market",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-26T07:00:00.000Z",
+					"start_date_at": "2027-12-08T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8950,6 +2830,24 @@
 		},
 		{
 			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
 			"channels": {
 				"set": [
 					"1"
@@ -8959,7 +2857,7 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-10-13T07:00:00.000Z",
+					"start_date_at": "2027-02-25T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8973,11 +2871,641 @@
 					"1"
 				]
 			},
+			"title": "Poetry Slam Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-12-31T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Poetry Slam Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-01T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fashion Show Runway",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Cultural Heritage Celebration",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-01-28T07:00:00.000Z",
+					"start_date_at": "2026-05-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sports Tournament Finals",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-05-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Theater Play Premiere",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-08-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Poetry Slam Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-05-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Food Truck Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Job Fair Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Charity Fun Run",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Business Leadership Conference",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Art Exhibition Opening",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Wine Tasting Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-10-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-10-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-02T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -8995,7 +3523,5479 @@
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-06-30T07:00:00.000Z",
+					"start_date_at": "2026-04-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-11-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Charity Fun Run",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Annual Charity Gala",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Marathon Race Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Charity Fun Run",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Startup Pitch Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Comedy Night Live",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Marathon Race Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Networking Mixer Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-08-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Wine Tasting Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-10-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-01-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gaming Convention",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-30T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Environmental Awareness Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-04-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Job Fair Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-10-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Holiday Craft Market",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Comedy Night Live",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Food Truck Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Marathon Race Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gardening Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Wine Tasting Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-02-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-04-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Wine Tasting Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-05-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-04-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-10-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Startup Pitch Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-11-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Job Fair Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Theater Play Premiere",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gardening Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-10-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Community Health Fair",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-04-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Photography Contest Awards",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Art Exhibition Opening",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Annual Charity Gala",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-10-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Theater Play Premiere",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-08-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Networking Mixer Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-05-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Marathon Race Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-02-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Business Leadership Conference",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-04-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Community Health Fair",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gaming Convention",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-31T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-08-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fashion Show Runway",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-10-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Startup Pitch Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Art Exhibition Opening",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-10-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-08-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Comedy Night Live",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-30T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gaming Convention",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Live Band Concert",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-11-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-04-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Marathon Race Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Photography Contest Awards",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fashion Show Runway",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Environmental Awareness Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Business Leadership Conference",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Holiday Craft Market",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-08-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-02-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Community Health Fair",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-10-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Food Truck Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-01T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Marathon Race Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Comedy Night Live",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-05-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Job Fair Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-10-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Wine Tasting Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Networking Mixer Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Theater Play Premiere",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Startup Pitch Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gardening Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Community Health Fair",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-02-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Annual Charity Gala",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Live Band Concert",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fashion Show Runway",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Business Leadership Conference",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-02-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Holiday Craft Market",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Marathon Race Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-11-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-30T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-10-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Holiday Craft Market",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-01-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-01T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Environmental Awareness Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-01-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Photography Contest Awards",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fitness Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-04-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Wine Tasting Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-10-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Holiday Craft Market",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sports Tournament Finals",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Networking Mixer Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Live Band Concert",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-05-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Comedy Night Live",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-02-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Holiday Craft Market",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Environmental Awareness Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fitness Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-10-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Charity Fun Run",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Holiday Craft Market",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-04-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-04-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-11-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Live Band Concert",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-05-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Wine Tasting Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Comedy Night Live",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Annual Charity Gala",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-01T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Startup Pitch Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gardening Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sports Tournament Finals",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Food Truck Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gaming Convention",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gardening Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Annual Charity Gala",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Art Exhibition Opening",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Environmental Awareness Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Environmental Awareness Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-01-01T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Job Fair Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-10-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fitness Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-04-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-30T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Theater Play Premiere",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Networking Mixer Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-31T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Theater Play Premiere",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fitness Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-08-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-02-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Theater Play Premiere",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Job Fair Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-11-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-01T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-10-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Poetry Slam Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-01T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Poetry Slam Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Art Exhibition Opening",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Holiday Craft Market",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fitness Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gaming Convention",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-01-31T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Poetry Slam Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-10-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Charity Fun Run",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-31T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-10-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Art Exhibition Opening",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Networking Mixer Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Business Leadership Conference",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-10-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-02-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-11-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Annual Charity Gala",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Theater Play Premiere",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fitness Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Holiday Craft Market",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-10-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-01-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-30T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"

--- a/data/leisure_events_automated.json
+++ b/data/leisure_events_automated.json
@@ -4,11 +4,16 @@
 	"data": [
 		{
 			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Public Speaking Workshop",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-07-14T07:00:00.000Z",
+					"start_date_at": "2025-07-14T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -17,11 +22,16 @@
 		},
 		{
 			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Sustainable Living Seminar",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-09-02T07:00:00.000Z",
+					"start_date_at": "2026-09-02T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -30,11 +40,16 @@
 		},
 		{
 			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Music Festival Extravaganza",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-01-13T07:00:00.000Z",
+					"start_date_at": "2025-01-13T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -43,11 +58,16 @@
 		},
 		{
 			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Startup Pitch Competition",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-01-12T07:00:00.000Z",
+					"start_date_at": "2025-01-12T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -56,11 +76,16 @@
 		},
 		{
 			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Meditation Session",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-05-17T07:00:00.000Z",
+					"start_date_at": "2027-05-17T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -69,11 +94,16 @@
 		},
 		{
 			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Networking Mixer Event",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-07-17T07:00:00.000Z",
+					"start_date_at": "2025-07-17T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -82,11 +112,16 @@
 		},
 		{
 			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Magic Show Spectacular",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-11-01T07:00:00.000Z",
+					"start_date_at": "2026-11-01T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -95,11 +130,16 @@
 		},
 		{
 			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Children's Storytime",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-10-04T07:00:00.000Z",
+					"start_date_at": "2025-10-04T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -108,11 +148,16 @@
 		},
 		{
 			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Community Health Fair",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-02-20T07:00:00.000Z",
+					"start_date_at": "2026-02-20T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -121,11 +166,16 @@
 		},
 		{
 			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Marathon Race Day",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-05-06T07:00:00.000Z",
+					"start_date_at": "2025-05-06T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -134,267 +184,12 @@
 		},
 		{
 			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Meditation Session",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-11T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Language Exchange Meetup",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-01-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Language Exchange Meetup",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-10-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Photography Contest Awards",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Business Leadership Conference",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-11-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Comedy Night Live",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Comedy Night Live",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Science Fair Showcase",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Annual Charity Gala",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-02-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Yoga Retreat Weekend",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
@@ -406,12 +201,89 @@
 			}
 		},
 		{
-			"account_id": "28",
-			"title": "Charity Fun Run",
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Art Exhibition Opening",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-06-07T07:00:00.000Z",
+					"start_date_at": "2025-09-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-10-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-20T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -420,50 +292,16 @@
 		},
 		{
 			"account_id": "13",
-			"title": "Film Screening Night",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-07-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-10-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Networking Mixer Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-05-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Startup Pitch Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-11-11T07:00:00.000Z",
+					"start_date_at": "2026-12-24T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -472,11 +310,16 @@
 		},
 		{
 			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Photography Contest Awards",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-12-25T07:00:00.000Z",
+					"start_date_at": "2025-09-27T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -484,8 +327,67 @@
 			}
 		},
 		{
-			"account_id": "36",
-			"title": "Magic Show Spectacular",
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Business Leadership Conference",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-11-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Comedy Night Live",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
@@ -497,480 +399,17 @@
 			}
 		},
 		{
-			"account_id": "7",
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
 			"account_id": "13",
-			"title": "Theater Play Premiere",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Photography Contest Awards",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-02-01T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Cultural Heritage Celebration",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Cultural Heritage Celebration",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-05-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Photography Contest Awards",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-11-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-01-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Live Band Concert",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Gardening Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Live Band Concert",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-01T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-01-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Job Fair Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Language Exchange Meetup",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-04-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Language Exchange Meetup",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Poetry Slam Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Business Leadership Conference",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Tech Innovation Summit",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-04-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-01-07T07:00:00.000Z",
+					"start_date_at": "2026-02-22T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -979,7 +418,12 @@
 		},
 		{
 			"account_id": "7",
-			"title": "Language Exchange Meetup",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
@@ -992,1870 +436,16 @@
 		},
 		{
 			"account_id": "28",
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Cultural Heritage Celebration",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-06-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Networking Mixer Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-02-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-06-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Photography Contest Awards",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Language Exchange Meetup",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Interior Design Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-02-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-31T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Language Exchange Meetup",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-06-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Wine Tasting Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Environmental Awareness Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-11T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-05-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Science Fair Showcase",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Live Band Concert",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Charity Fun Run",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-31T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Charity Fun Run",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Annual Charity Gala",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-04-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-01T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Language Exchange Meetup",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-05-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Cultural Heritage Celebration",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Sports Tournament Finals",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-10-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Fashion Show Runway",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Networking Mixer Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Sports Tournament Finals",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Gaming Convention",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-02-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Environmental Awareness Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Fitness Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Meditation Session",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-31T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Interior Design Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Sports Tournament Finals",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-05-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Startup Pitch Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Poetry Slam Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Sports Tournament Finals",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Job Fair Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Sports Tournament Finals",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Fitness Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Poetry Slam Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Interior Design Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-06-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Annual Charity Gala",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Poetry Slam Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2023-12-31T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-05-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Poetry Slam Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-11-01T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Fashion Show Runway",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-05-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Cultural Heritage Celebration",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Sports Tournament Finals",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-04-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Theater Play Premiere",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Poetry Slam Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Food Truck Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-11T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Job Fair Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-06-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Charity Fun Run",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-02-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Business Leadership Conference",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Interior Design Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Wine Tasting Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-10-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-11-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Charity Fun Run",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Annual Charity Gala",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-05-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Marathon Race Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Charity Fun Run",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Startup Pitch Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-06-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Comedy Night Live",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-08-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Marathon Race Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Networking Mixer Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Wine Tasting Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-26T07:00:00.000Z",
+					"start_date_at": "2025-09-23T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -2864,193 +454,16 @@
 		},
 		{
 			"account_id": "28",
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Language Exchange Meetup",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-01-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Gaming Convention",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-30T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Environmental Awareness Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Job Fair Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Sustainable Living Seminar",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-07-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Meditation Session",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-06-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Holiday Craft Market",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-11-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-06-21T07:00:00.000Z",
+					"start_date_at": "2025-10-22T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -3059,89 +472,16 @@
 		},
 		{
 			"account_id": "36",
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Science Fair Showcase",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-07-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Comedy Night Live",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-02-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-02-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Cultural Heritage Celebration",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Food Truck Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-11T07:00:00.000Z",
+					"start_date_at": "2027-06-12T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -3150,492 +490,16 @@
 		},
 		{
 			"account_id": "13",
-			"title": "Marathon Race Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Gardening Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Wine Tasting Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Science Fair Showcase",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Wine Tasting Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Mental Health Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-01-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Startup Pitch Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-02-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Meditation Session",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-11-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Job Fair Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Theater Play Premiere",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Gardening Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Tech Innovation Summit",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Science Fair Showcase",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Community Health Fair",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Interior Design Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-06-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Photography Contest Awards",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Annual Charity Gala",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-02-15T07:00:00.000Z",
+					"start_date_at": "2025-02-22T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -3644,76 +508,16 @@
 		},
 		{
 			"account_id": "28",
-			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-10-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Theater Play Premiere",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Virtual Reality Experience",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-08-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Networking Mixer Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-02T07:00:00.000Z",
+					"start_date_at": "2026-05-08T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -3722,24 +526,16 @@
 		},
 		{
 			"account_id": "7",
-			"title": "Coding Bootcamp",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-08-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Mental Health Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-08T07:00:00.000Z",
+					"start_date_at": "2026-09-03T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -3748,7 +544,156 @@
 		},
 		{
 			"account_id": "13",
-			"title": "Marathon Race Day",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Charity Fun Run",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-10-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Networking Mixer Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Startup Pitch Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Photography Contest Awards",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
@@ -3761,24 +706,16 @@
 		},
 		{
 			"account_id": "13",
-			"title": "Business Leadership Conference",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Theater Play Premiere",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-04-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-06-25T07:00:00.000Z",
+					"start_date_at": "2025-09-15T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -3787,11 +724,34 @@
 		},
 		{
 			"account_id": "36",
-			"title": "Science Fair Showcase",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Photography Contest Awards",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-09-16T07:00:00.000Z",
+					"start_date_at": "2026-05-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-01T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -3800,11 +760,34 @@
 		},
 		{
 			"account_id": "28",
-			"title": "Community Health Fair",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-12-28T07:00:00.000Z",
+					"start_date_at": "2025-09-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-28T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -3813,7 +796,390 @@
 		},
 		{
 			"account_id": "7",
-			"title": "Astronomy Night",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Photography Contest Awards",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-11-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Art Exhibition Opening",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-01-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Live Band Concert",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-08-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Art Exhibition Opening",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gardening Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Live Band Concert",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-01T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Job Fair Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
@@ -3825,12 +1191,17 @@
 			}
 		},
 		{
-			"account_id": "7",
-			"title": "Gaming Convention",
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-01-31T07:00:00.000Z",
+					"start_date_at": "2025-07-16T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -3839,11 +1210,142 @@
 		},
 		{
 			"account_id": "13",
-			"title": "Meditation Session",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Poetry Slam Night",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-08-07T07:00:00.000Z",
+					"start_date_at": "2026-04-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-10-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Business Leadership Conference",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-04-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-07T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -3852,11 +1354,52 @@
 		},
 		{
 			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Cultural Heritage Celebration",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-05-22T07:00:00.000Z",
+					"start_date_at": "2025-06-02T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -3865,11 +1408,16 @@
 		},
 		{
 			"account_id": "7",
-			"title": "Craft Beer Festival",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Networking Mixer Event",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-04-02T07:00:00.000Z",
+					"start_date_at": "2025-02-28T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -3877,12 +1425,17 @@
 			}
 		},
 		{
-			"account_id": "28",
-			"title": "Fashion Show Runway",
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-10-20T07:00:00.000Z",
+					"start_date_at": "2025-06-18T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -3890,8 +1443,85 @@
 			}
 		},
 		{
-			"account_id": "28",
-			"title": "Startup Pitch Competition",
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Photography Contest Awards",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
@@ -3903,12 +1533,35 @@
 			}
 		},
 		{
-			"account_id": "36",
-			"title": "Interior Design Workshop",
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-05-24T07:00:00.000Z",
+					"start_date_at": "2027-03-31T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-21T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -3917,11 +1570,16 @@
 		},
 		{
 			"account_id": "13",
-			"title": "Pet Adoption Event",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-06-07T07:00:00.000Z",
+					"start_date_at": "2025-10-16T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -3930,11 +1588,16 @@
 		},
 		{
 			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Art Exhibition Opening",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-01-10T07:00:00.000Z",
+					"start_date_at": "2026-02-18T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -3942,190 +1605,13 @@
 			}
 		},
 		{
-			"account_id": "28",
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Meditation Session",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Comedy Night Live",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-04-30T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-04-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Gaming Convention",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Live Band Concert",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-11-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Mental Health Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Marathon Race Day",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
@@ -4137,12 +1623,17 @@
 			}
 		},
 		{
-			"account_id": "28",
-			"title": "Photography Contest Awards",
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-07-27T07:00:00.000Z",
+					"start_date_at": "2025-06-12T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -4151,11 +1642,16 @@
 		},
 		{
 			"account_id": "13",
-			"title": "Fashion Show Runway",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Wine Tasting Event",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-09-05T07:00:00.000Z",
+					"start_date_at": "2027-12-28T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -4163,12 +1659,17 @@
 			}
 		},
 		{
-			"account_id": "13",
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Environmental Awareness Workshop",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-03-13T07:00:00.000Z",
+					"start_date_at": "2025-12-20T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -4177,128 +1678,16 @@
 		},
 		{
 			"account_id": "13",
-			"title": "Mental Health Seminar",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-01-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Interior Design Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Business Leadership Conference",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-04-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Holiday Craft Market",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Community Health Fair",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-01-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-12T07:00:00.000Z",
+					"start_date_at": "2026-12-19T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -4307,11 +1696,52 @@
 		},
 		{
 			"account_id": "28",
-			"title": "Coding Bootcamp",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-10-08T07:00:00.000Z",
+					"start_date_at": "2025-12-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-17T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -4320,7 +1750,264 @@
 		},
 		{
 			"account_id": "7",
-			"title": "Food Truck Festival",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Live Band Concert",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Charity Fun Run",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-31T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Charity Fun Run",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Annual Charity Gala",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
@@ -4333,1298 +2020,16 @@
 		},
 		{
 			"account_id": "7",
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-01T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Marathon Race Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Comedy Night Live",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Language Exchange Meetup",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Job Fair Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-10-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Wine Tasting Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Science Fair Showcase",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-01-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Networking Mixer Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-01-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Theater Play Premiere",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-07-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-11T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Meditation Session",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-11-11T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Startup Pitch Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Gardening Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Community Health Fair",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Meditation Session",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Mental Health Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Annual Charity Gala",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-02-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Live Band Concert",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-12T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Fashion Show Runway",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Business Leadership Conference",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-11-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Music Festival Extravaganza",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Holiday Craft Market",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Marathon Race Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-11-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-30T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Science Fair Showcase",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Holiday Craft Market",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-01-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-01T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Fundraising Dinner",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Environmental Awareness Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-01-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Meditation Session",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Volunteer Appreciation Day",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Photography Contest Awards",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-04-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-11-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-05-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Cultural Heritage Celebration",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Mental Health Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-11-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Fitness Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Wine Tasting Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-05-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Science Fair Showcase",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-10-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Holiday Craft Market",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Public Speaking Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Interior Design Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-28T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Mental Health Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Sports Tournament Finals",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Networking Mixer Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-11T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Travel Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Live Band Concert",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Comedy Night Live",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-05-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-11T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Science Fair Showcase",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-02-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Cooking Class Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Holiday Craft Market",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-21T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Mental Health Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Environmental Awareness Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-08T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Fitness Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-10-06T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Charity Fun Run",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Holiday Craft Market",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Astronomy Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-11-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Live Band Concert",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-07T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-05-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Wine Tasting Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Film Screening Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Comedy Night Live",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-02-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-05-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Annual Charity Gala",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-01T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Cultural Heritage Celebration",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-10T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Startup Pitch Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Mental Health Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-12-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Gardening Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-12-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Sports Tournament Finals",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Food Truck Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Gaming Convention",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-12-25T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Gardening Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Annual Charity Gala",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-07-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Interior Design Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Art Exhibition Opening",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-07-22T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Environmental Awareness Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-09T07:00:00.000Z",
+					"start_date_at": "2025-04-08T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5633,11 +2038,16 @@
 		},
 		{
 			"account_id": "7",
-			"title": "Virtual Reality Experience",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-07-11T07:00:00.000Z",
+					"start_date_at": "2027-02-01T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5645,12 +2055,17 @@
 			}
 		},
 		{
-			"account_id": "28",
-			"title": "Environmental Awareness Workshop",
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-01-01T07:00:00.000Z",
+					"start_date_at": "2025-05-21T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5658,51 +2073,17 @@
 			}
 		},
 		{
-			"account_id": "36",
-			"title": "Job Fair Expo",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-04-16T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Robotics Competition",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-10-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Robotics Competition",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-11-16T07:00:00.000Z",
+					"start_date_at": "2026-06-03T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5711,76 +2092,16 @@
 		},
 		{
 			"account_id": "7",
-			"title": "Fitness Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-04-14T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Pet Adoption Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-06-30T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Yoga Retreat Weekend",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-09-13T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Theater Play Premiere",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-03-27T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Networking Mixer Event",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Film Screening Night",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-03-31T07:00:00.000Z",
+					"start_date_at": "2026-06-08T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5789,11 +2110,52 @@
 		},
 		{
 			"account_id": "28",
-			"title": "Travel Expo",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-11-20T07:00:00.000Z",
+					"start_date_at": "2027-02-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sports Tournament Finals",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-10-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fashion Show Runway",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-09T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5802,11 +2164,16 @@
 		},
 		{
 			"account_id": "7",
-			"title": "Theater Play Premiere",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Networking Mixer Event",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-07-17T07:00:00.000Z",
+					"start_date_at": "2025-10-23T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5815,11 +2182,52 @@
 		},
 		{
 			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Public Speaking Workshop",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-03-17T07:00:00.000Z",
+					"start_date_at": "2026-09-02T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5827,73 +2235,13 @@
 			}
 		},
 		{
-			"account_id": "36",
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Fitness Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-08-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-23T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Craft Beer Festival",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-18T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Language Exchange Meetup",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
@@ -5906,37 +2254,16 @@
 		},
 		{
 			"account_id": "13",
-			"title": "Sustainable Living Seminar",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-12-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Magic Show Spectacular",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Book Launch Party",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-08-08T07:00:00.000Z",
+					"start_date_at": "2027-05-24T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5945,11 +2272,16 @@
 		},
 		{
 			"account_id": "13",
-			"title": "Public Speaking Workshop",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sports Tournament Finals",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-02-07T07:00:00.000Z",
+					"start_date_at": "2026-12-27T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5958,24 +2290,16 @@
 		},
 		{
 			"account_id": "13",
-			"title": "Children's Storytime",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gaming Convention",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-07-04T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Interior Design Workshop",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-02-15T07:00:00.000Z",
+					"start_date_at": "2025-02-16T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5984,11 +2308,70 @@
 		},
 		{
 			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Environmental Awareness Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-02-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fitness Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Meditation Session",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-02-17T07:00:00.000Z",
+					"start_date_at": "2027-01-31T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -5996,25 +2379,17 @@
 			}
 		},
 		{
-			"account_id": "13",
-			"title": "Dance Performance Recital",
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-06-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Theater Play Premiere",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-04-10T07:00:00.000Z",
+					"start_date_at": "2026-02-07T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6023,11 +2398,16 @@
 		},
 		{
 			"account_id": "28",
-			"title": "Job Fair Expo",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-11-22T07:00:00.000Z",
+					"start_date_at": "2025-12-04T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6036,11 +2416,52 @@
 		},
 		{
 			"account_id": "7",
-			"title": "Robotics Competition",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-06-13T07:00:00.000Z",
+					"start_date_at": "2026-04-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sports Tournament Finals",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Startup Pitch Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-10-14T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6049,7 +2470,732 @@
 		},
 		{
 			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Poetry Slam Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sports Tournament Finals",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-02-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-02-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Job Fair Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sports Tournament Finals",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-05-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fitness Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Poetry Slam Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-05-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Annual Charity Gala",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-08-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-02-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Poetry Slam Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2024-12-31T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Poetry Slam Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-01T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fashion Show Runway",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sports Tournament Finals",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-05-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Theater Play Premiere",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-08-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Poetry Slam Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-05-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Food Truck Festival",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
@@ -6061,12 +3207,17 @@
 			}
 		},
 		{
-			"account_id": "28",
-			"title": "Public Speaking Workshop",
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Job Fair Expo",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-11-01T07:00:00.000Z",
+					"start_date_at": "2025-06-13T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6075,11 +3226,178 @@
 		},
 		{
 			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Charity Fun Run",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Business Leadership Conference",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Art Exhibition Opening",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Cooking Class Series",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-04-11T07:00:00.000Z",
+					"start_date_at": "2026-06-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-14T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6088,7 +3406,2100 @@
 		},
 		{
 			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Wine Tasting Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-10-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-10-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-11-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Charity Fun Run",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Annual Charity Gala",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Marathon Race Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Charity Fun Run",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Startup Pitch Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Comedy Night Live",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Marathon Race Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Networking Mixer Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-08-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Wine Tasting Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-10-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-01-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gaming Convention",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-30T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Environmental Awareness Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-04-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Job Fair Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-10-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Holiday Craft Market",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Comedy Night Live",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Food Truck Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Marathon Race Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gardening Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Wine Tasting Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-02-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-04-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Wine Tasting Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-05-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-04-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-10-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Startup Pitch Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-11-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Job Fair Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Theater Play Premiere",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gardening Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Tech Innovation Summit",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-10-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Community Health Fair",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-04-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Photography Contest Awards",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Art Exhibition Opening",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Annual Charity Gala",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-10-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Theater Play Premiere",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-08-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Networking Mixer Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-05-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Marathon Race Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-02-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Business Leadership Conference",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-04-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Community Health Fair",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gaming Convention",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-31T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-08-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fashion Show Runway",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-10-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Startup Pitch Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Art Exhibition Opening",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
@@ -6101,76 +5512,16 @@
 		},
 		{
 			"account_id": "36",
-			"title": "Volunteer Appreciation Day",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-12-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Poetry Slam Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-08-01T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "28",
-			"title": "Sustainable Living Seminar",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-09-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Poetry Slam Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-05T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Holiday Craft Market",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-07-21T07:00:00.000Z",
+					"start_date_at": "2026-04-04T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6179,11 +5530,34 @@
 		},
 		{
 			"account_id": "13",
-			"title": "Fitness Bootcamp",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-12-08T07:00:00.000Z",
+					"start_date_at": "2027-08-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Comedy Night Live",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-30T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6192,11 +5566,16 @@
 		},
 		{
 			"account_id": "28",
-			"title": "Historical Lecture Series",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-02-10T07:00:00.000Z",
+					"start_date_at": "2025-12-07T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6204,12 +5583,17 @@
 			}
 		},
 		{
-			"account_id": "36",
-			"title": "Virtual Reality Experience",
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-12-02T07:00:00.000Z",
+					"start_date_at": "2026-04-23T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6217,103 +5601,35 @@
 			}
 		},
 		{
-			"account_id": "36",
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Gaming Convention",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-01-31T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Poetry Slam Night",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-03-20T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-10-24T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Charity Fun Run",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-03-31T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Children's Storytime",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-10-02T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Art Exhibition Opening",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-06-09T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Cultural Heritage Celebration",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Virtual Reality Experience",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-06-17T07:00:00.000Z",
+					"start_date_at": "2025-03-25T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6322,11 +5638,52 @@
 		},
 		{
 			"account_id": "28",
-			"title": "Networking Mixer Event",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Live Band Concert",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-04-24T07:00:00.000Z",
+					"start_date_at": "2027-11-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-04-25T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6335,11 +5692,16 @@
 		},
 		{
 			"account_id": "7",
-			"title": "Business Leadership Conference",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2025-10-11T07:00:00.000Z",
+					"start_date_at": "2025-07-10T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6348,7 +5710,2046 @@
 		},
 		{
 			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Marathon Race Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Photography Contest Awards",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fashion Show Runway",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Environmental Awareness Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Business Leadership Conference",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Holiday Craft Market",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-08-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-02-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Community Health Fair",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-10-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Food Truck Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-01T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Marathon Race Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Comedy Night Live",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-05-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Job Fair Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-10-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Wine Tasting Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Networking Mixer Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-01-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Theater Play Premiere",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Startup Pitch Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gardening Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Community Health Fair",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-02-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Annual Charity Gala",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Live Band Concert",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-12T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fashion Show Runway",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Business Leadership Conference",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Music Festival Extravaganza",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-02-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Holiday Craft Market",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Marathon Race Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-11-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-30T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-10-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Holiday Craft Market",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-01-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-01T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fundraising Dinner",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Environmental Awareness Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-01-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Photography Contest Awards",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fitness Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-04-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Wine Tasting Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-10-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Holiday Craft Market",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sports Tournament Finals",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Networking Mixer Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Live Band Concert",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-05-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Comedy Night Live",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Science Fair Showcase",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-02-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Holiday Craft Market",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Environmental Awareness Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fitness Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-10-06T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Charity Fun Run",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Holiday Craft Market",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-04-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Astronomy Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-04-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-11-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Live Band Concert",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-05-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Wine Tasting Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Comedy Night Live",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-05-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Annual Charity Gala",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-01T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Startup Pitch Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-12-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gardening Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sports Tournament Finals",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Food Truck Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gaming Convention",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-25T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gardening Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Annual Charity Gala",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
@@ -6360,51 +7761,17 @@
 			}
 		},
 		{
-			"account_id": "36",
-			"title": "Meditation Session",
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Art Exhibition Opening",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2026-11-17T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Coding Bootcamp",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-05-19T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Annual Charity Gala",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-09-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Theater Play Premiere",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-06-19T07:00:00.000Z",
+					"start_date_at": "2027-07-22T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6413,24 +7780,16 @@
 		},
 		{
 			"account_id": "36",
-			"title": "Cultural Heritage Celebration",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Environmental Awareness Workshop",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-04-15T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "13",
-			"title": "Historical Lecture Series",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2024-11-24T07:00:00.000Z",
+					"start_date_at": "2025-03-09T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6439,37 +7798,16 @@
 		},
 		{
 			"account_id": "7",
-			"title": "Fitness Bootcamp",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-02-03T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "7",
-			"title": "Holiday Craft Market",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2026-01-26T07:00:00.000Z",
-					"start_time": "16:00",
-					"end_time": "20:00",
-					"frequency_id": "single_date"
-				}
-			}
-		},
-		{
-			"account_id": "36",
-			"title": "Dance Performance Recital",
-			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
-			"date_rule_sets": {
-				"docs": {
-					"start_date_at": "2025-10-13T07:00:00.000Z",
+					"start_date_at": "2025-07-11T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6478,11 +7816,16 @@
 		},
 		{
 			"account_id": "28",
-			"title": "Cultural Heritage Celebration",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Environmental Awareness Workshop",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-01-28T07:00:00.000Z",
+					"start_date_at": "2025-01-01T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"
@@ -6491,11 +7834,1168 @@
 		},
 		{
 			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Job Fair Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-10-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-16T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fitness Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-04-14T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Pet Adoption Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-30T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Yoga Retreat Weekend",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-09-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Theater Play Premiere",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-27T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Networking Mixer Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Film Screening Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-31T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-11-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Theater Play Premiere",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-03-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"title": "Children's Storytime",
 			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 			"date_rule_sets": {
 				"docs": {
-					"start_date_at": "2024-06-30T07:00:00.000Z",
+					"start_date_at": "2026-06-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fitness Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-08-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Craft Beer Festival",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-18T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Language Exchange Meetup",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-07-23T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Magic Show Spectacular",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Book Launch Party",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-08-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-07T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-07-04T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Interior Design Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-02-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Theater Play Premiere",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Job Fair Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-11-22T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Robotics Competition",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Travel Expo",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-01T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cooking Class Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-04-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Mental Health Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-10-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Volunteer Appreciation Day",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Poetry Slam Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-08-01T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Sustainable Living Seminar",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-09-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Poetry Slam Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-05T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Art Exhibition Opening",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Holiday Craft Market",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-07-21T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fitness Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-12-08T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-02-10T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-12-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Gaming Convention",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-01-31T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Poetry Slam Night",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-03-20T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-10-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Charity Fun Run",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-03-31T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-10-02T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Art Exhibition Opening",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-06-09T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Virtual Reality Experience",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-06-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Networking Mixer Event",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Business Leadership Conference",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-10-11T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Public Speaking Workshop",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-02-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Meditation Session",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-11-17T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Coding Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-05-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Annual Charity Gala",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-09-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Theater Play Premiere",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-19T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-04-15T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "13",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Historical Lecture Series",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-11-24T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Fitness Bootcamp",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-02-03T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "7",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Holiday Craft Market",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2027-01-26T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Dance Performance Recital",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2026-10-13T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "28",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Cultural Heritage Celebration",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-01-28T07:00:00.000Z",
+					"start_time": "16:00",
+					"end_time": "20:00",
+					"frequency_id": "single_date"
+				}
+			}
+		},
+		{
+			"account_id": "36",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
+			"title": "Children's Storytime",
+			"description": "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
+			"date_rule_sets": {
+				"docs": {
+					"start_date_at": "2025-06-30T07:00:00.000Z",
 					"start_time": "16:00",
 					"end_time": "20:00",
 					"frequency_id": "single_date"

--- a/data/listings.json
+++ b/data/listings.json
@@ -13,7 +13,8 @@
 					"categories": { "set": ["2"] },
 					"subcategories": { "set": ["4"] }
 				}
-			}
+			},
+			"channels": { "set": ["1"] }
 		},
 		{
 			"title": "Starr Pass Resort - Accommodations - Resorts",
@@ -31,26 +32,30 @@
 			"description": "The 98 acre Desert Museum is a fusion experience: zoo, botanical garden, art gallery, natural history museum, and aquarium.   The Desert Museum is ranked on TripAdvisor.com as one of the Top 10 Museums in the country and the #1 Tucson attraction. Unlike most museums, about 85% of the experience is outdoors! ",
 			"keywords": "Outdoor, museum, Zoo",
 			"property": { "set": "4" },
-			"subcategories": { "set": ["8"] }
+			"subcategories": { "set": ["8"] },
+			"channels": { "set": ["1"] }
 		},
 		{
 			"title": "611 Pub, Inc. - Dining - Bar & Grill",
 			"description": "Easy to Find, Hard to Leave! Pit 611 is your friendly neighborhood bar and grill situated near Audubon, in the heart of Minnesota’s beautiful lakes country. Our clean, relaxed, family-friendly atmosphere provides the perfect backdrop for delicious, home cooked meals, a wide selection of beverages and an all-around great time. Dining options include an outdoor patio with a gorgeous view. Located at the corner of county highways 6 and 11, we’re the easy to find, hard to leave place you won’t soon forget!",
 			"keywords": "Local, Pub",
 			"property": { "set": "2" },
-			"subcategories": { "set": ["6"] }
+			"subcategories": { "set": ["6"] },
+			"channels": { "set": ["1"] }
 		},
 		{
 			"title": "A Cottage At Campbell Farm - Accommodations - Extended Stay",
 			"description": "Private, Romantic, Picturesque and Tranquil. Nestled between pond and forest on our 1780's mountain farm, our cottages are a perfect retreat or a base from which to explore.",
 			"keywords": "Cottages, Cabins",
 			"property": { "set": "5" },
-			"subcategories": { "set": ["7"] }
+			"subcategories": { "set": ["7"] },
+			"channels": { "set": ["1"] }
 		},
 		{
 			"title": "4th Street Event Center Listing",
 			"property": { "set": "6" },
-			"property_id": "6"
+			"property_id": "6",
+			"channels": { "set": ["1"] }
 		},
 		{
 			"title": "Club at Starr Pass",
@@ -135,7 +140,7 @@
 			"rank": { "set": "2" },
 			"channels": { "set": ["1"] },
 			"post_from_at": "2024-01-01T07:00:00.000Z",
-			"post_to_at": "2025-12-15T07:00:00.000Z"
+			"post_to_at": "2027-12-31T07:00:00.000Z"
 		},
 		{
 			"property": { "set": "14" },
@@ -146,7 +151,7 @@
 			"rank": { "set": "2" },
 			"channels": { "set": ["1"] },
 			"post_from_at": "2024-01-01T07:00:00.000Z",
-			"post_to_at": "2025-12-15T07:00:00.000Z"
+			"post_to_at": "2027-12-31T07:00:00.000Z"
 		},
 		{
 			"property": { "set": "15" },
@@ -157,7 +162,7 @@
 			"rank": { "set": "2" },
 			"channels": { "set": ["1"] },
 			"post_from_at": "2024-01-01T07:00:00.000Z",
-			"post_to_at": "2025-12-15T07:00:00.000Z"
+			"post_to_at": "2027-12-31T07:00:00.000Z"
 		},
 		{
 			"property": { "set": "16" },
@@ -168,7 +173,7 @@
 			"rank": { "set": "2" },
 			"channels": { "set": ["1", "3", "4"] },
 			"post_from_at": "2024-01-01T07:00:00.000Z",
-			"post_to_at": "2025-12-15T07:00:00.000Z"
+			"post_to_at": "2027-12-31T07:00:00.000Z"
 		},
 		{
 			"property": { "set": "17" },
@@ -179,7 +184,7 @@
 			"rank": { "set": "2" },
 			"channels": { "set": ["1", "3", "4"] },
 			"post_from_at": "2024-01-01T07:00:00.000Z",
-			"post_to_at": "2025-12-15T07:00:00.000Z"
+			"post_to_at": "2027-12-31T07:00:00.000Z"
 		},
 		{
 			"property": { "set": "18" },
@@ -190,7 +195,7 @@
 			"rank": { "set": "2" },
 			"channels": { "set": ["1", "3", "4"] },
 			"post_from_at": "2024-01-01T07:00:00.000Z",
-			"post_to_at": "2025-12-15T07:00:00.000Z"
+			"post_to_at": "2027-12-31T07:00:00.000Z"
 		},
 		{
 			"property": { "set": "19" },
@@ -540,7 +545,7 @@
 			"rank": { "set": "3" },
 			"channels": { "set": ["1"] },
 			"post_from_at": "2024-01-01T07:00:00.000Z",
-			"post_to_at": "2025-12-15T07:00:00.000Z"
+			"post_to_at": "2027-12-31T07:00:00.000Z"
 		},
 		{
 			"property": { "set": "52" },
@@ -551,7 +556,7 @@
 			"rank": { "set": "3" },
 			"channels": { "set": ["1"] },
 			"post_from_at": "2024-01-01T07:00:00.000Z",
-			"post_to_at": "2025-12-15T07:00:00.000Z",
+			"post_to_at": "2027-12-31T07:00:00.000Z",
 			"dtn": {
 				"doc": {
 					"is_enabled": true,
@@ -569,7 +574,7 @@
 			"rank": { "set": "3" },
 			"channels": { "set": ["1"] },
 			"post_from_at": "2024-01-01T07:00:00.000Z",
-			"post_to_at": "2025-12-15T07:00:00.000Z"
+			"post_to_at": "2027-12-31T07:00:00.000Z"
 		},
 		{
 			"property": { "set": "54" },
@@ -580,7 +585,7 @@
 			"rank": { "set": "3" },
 			"channels": { "set": ["1"] },
 			"post_from_at": "2024-01-01T07:00:00.000Z",
-			"post_to_at": "2025-12-15T07:00:00.000Z"
+			"post_to_at": "2027-12-31T07:00:00.000Z"
 		},
 		{
 			"property": { "set": "55" },
@@ -591,7 +596,7 @@
 			"rank": { "set": "3" },
 			"channels": { "set": ["1"] },
 			"post_from_at": "2024-01-01T07:00:00.000Z",
-			"post_to_at": "2025-12-15T07:00:00.000Z"
+			"post_to_at": "2027-12-31T07:00:00.000Z"
 		},
 		{
 			"property": { "set": "56" },

--- a/data/offers.json
+++ b/data/offers.json
@@ -4,7 +4,8 @@
 		{
 			"account": { "set": "13" },
 			"media": null,
-			"title": "My 4th Street Basic Offer"
+			"title": "My 4th Street Basic Offer",
+			"channels": { "set": ["1"] }
 		},
 		{
 			"account": { "set": "13" },
@@ -49,9 +50,9 @@
 			"rank": { "set": "2" },
 			"is_featured": true,
 			"post_from_at": "2026-02-01T07:00:00.000Z",
-			"post_to_at": "2026-01-01T07:00:00.000Z",
+			"post_to_at": "2027-01-01T07:00:00.000Z",
 			"redeem_from_at": "2026-03-01T07:00:00.000Z",
-			"redeem_to_at": "2026-01-15T07:00:00.000Z",
+			"redeem_to_at": "2027-01-15T07:00:00.000Z",
 			"description": "Escape to a world of serenity and relaxation with our Spa Retreats Package at the JW Marriott Starr Pass. \nUnwind, rejuvenate, and embrace the tranquility of every moment. Your retreat includes one 50 minute spa treatment per day, and a daily resort credit of $50. Your pathway to unparalleled is one click away.\nHow to Book\n\nBe sure that the Promotional Code appears in the Corporate/Promotional code box when making your online reservation, or call 520-791-6117 and ask for the promotional code. For toll-free numbers outside the US please visit Global Reservation Numbers\nNeed to Know\n\n    Promotional Code: SPA\n    Valid stay dates: January 18, 2026 - January 15, 2026\n",
 			"title": "Spa Retreats - Relax and Rejuvenate",
 			"weburl": "https://www.marriott.com/offers/spa-retreats-package-off-88552/tussp-jw-marriott-tucson-starr-pass-resort-and-spa?propertycode=tussp"
@@ -148,10 +149,10 @@
 			"is_featured": false,
 			"listings": { "set": ["80"] },
 			"post_from_at": "2026-10-01T07:00:00.000Z",
-			"post_to_at": "2026-03-31T07:00:00.000Z",
+			"post_to_at": "2027-03-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-08-01T07:00:00.000Z",
-			"redeem_to_at": "2026-03-31T07:00:00.000Z",
+			"redeem_to_at": "2027-03-31T07:00:00.000Z",
 			"title": "Restaurant Week Cantina"
 		},
 		{
@@ -162,10 +163,10 @@
 			"is_featured": false,
 			"listings": { "set": ["103"] },
 			"post_from_at": "2026-09-01T07:00:00.000Z",
-			"post_to_at": "2026-05-31T07:00:00.000Z",
+			"post_to_at": "2027-05-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-09-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Discount for IKON Pass Holders"
 		},
 		{
@@ -176,10 +177,10 @@
 			"is_featured": false,
 			"listings": { "set": ["108"] },
 			"post_from_at": "2026-09-01T07:00:00.000Z",
-			"post_to_at": "2026-05-31T07:00:00.000Z",
+			"post_to_at": "2027-05-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-09-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Child Season Pass"
 		},
 		{
@@ -190,10 +191,10 @@
 			"is_featured": false,
 			"listings": { "set": ["108"] },
 			"post_from_at": "2026-09-01T07:00:00.000Z",
-			"post_to_at": "2026-05-31T07:00:00.000Z",
+			"post_to_at": "2027-05-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-09-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Seasonal Ski and Snowboard Rentals"
 		},
 		{
@@ -204,10 +205,10 @@
 			"is_featured": false,
 			"listings": { "set": ["108"] },
 			"post_from_at": "2026-09-01T07:00:00.000Z",
-			"post_to_at": "2026-05-31T07:00:00.000Z",
+			"post_to_at": "2027-05-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-09-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Seasonal Locker Rental"
 		},
 		{
@@ -218,10 +219,10 @@
 			"is_featured": false,
 			"listings": { "set": ["108"] },
 			"post_from_at": "2026-09-01T07:00:00.000Z",
-			"post_to_at": "2026-05-31T07:00:00.000Z",
+			"post_to_at": "2027-05-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-09-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Off Peak Season Pass"
 		},
 		{
@@ -232,10 +233,10 @@
 			"is_featured": false,
 			"listings": { "set": ["108"] },
 			"post_from_at": "2026-09-01T07:00:00.000Z",
-			"post_to_at": "2026-05-31T07:00:00.000Z",
+			"post_to_at": "2027-05-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-09-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Senior Season Pass"
 		},
 		{
@@ -274,10 +275,10 @@
 			"is_featured": false,
 			"listings": { "set": ["110"] },
 			"post_from_at": "2026-06-03T07:00:00.000Z",
-			"post_to_at": "2026-03-01T07:00:00.000Z",
+			"post_to_at": "2027-03-01T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-07-06T07:00:00.000Z",
-			"redeem_to_at": "2026-03-01T07:00:00.000Z",
+			"redeem_to_at": "2027-03-01T07:00:00.000Z",
 			"title": "$0.75 Cent Wing Nights"
 		},
 		{
@@ -400,10 +401,10 @@
 			"is_featured": false,
 			"listings": { "set": ["12"] },
 			"post_from_at": "2026-03-01T07:00:00.000Z",
-			"post_to_at": "2026-01-31T07:00:00.000Z",
+			"post_to_at": "2027-01-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-03-01T07:00:00.000Z",
-			"redeem_to_at": "2026-01-31T07:00:00.000Z",
+			"redeem_to_at": "2027-01-31T07:00:00.000Z",
 			"title": "Couples Getaway Package"
 		},
 		{
@@ -442,10 +443,10 @@
 			"is_featured": false,
 			"listings": { "set": ["15"] },
 			"post_from_at": "2026-03-01T07:00:00.000Z",
-			"post_to_at": "2026-01-31T07:00:00.000Z",
+			"post_to_at": "2027-01-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-03-01T07:00:00.000Z",
-			"redeem_to_at": "2026-01-31T07:00:00.000Z",
+			"redeem_to_at": "2027-01-31T07:00:00.000Z",
 			"title": "Margarita Mondays"
 		},
 		{
@@ -470,10 +471,10 @@
 			"is_featured": false,
 			"listings": { "set": ["20"] },
 			"post_from_at": "2026-12-01T07:00:00.000Z",
-			"post_to_at": "2026-01-03T07:00:00.000Z",
+			"post_to_at": "2027-01-03T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-12-01T07:00:00.000Z",
-			"redeem_to_at": "2026-01-03T07:00:00.000Z",
+			"redeem_to_at": "2027-01-03T07:00:00.000Z",
 			"title": "New Years Eve on the River"
 		},
 		{
@@ -526,10 +527,10 @@
 			"is_featured": false,
 			"listings": { "set": ["25"] },
 			"post_from_at": "2026-10-01T07:00:00.000Z",
-			"post_to_at": "2026-05-31T07:00:00.000Z",
+			"post_to_at": "2027-05-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-10-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Murder Mystery Weekends"
 		},
 		{
@@ -540,10 +541,10 @@
 			"is_featured": false,
 			"listings": { "set": ["33"] },
 			"post_from_at": "2026-10-01T07:00:00.000Z",
-			"post_to_at": "2026-05-31T07:00:00.000Z",
+			"post_to_at": "2027-05-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-10-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Date Night at Lucky 8"
 		},
 		{
@@ -554,10 +555,10 @@
 			"is_featured": false,
 			"listings": { "set": ["33"] },
 			"post_from_at": "2026-10-01T07:00:00.000Z",
-			"post_to_at": "2026-05-31T07:00:00.000Z",
+			"post_to_at": "2027-05-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-10-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Half Price Student Discount Days"
 		},
 		{
@@ -568,10 +569,10 @@
 			"is_featured": false,
 			"listings": { "set": ["33"] },
 			"post_from_at": "2026-10-01T07:00:00.000Z",
-			"post_to_at": "2026-05-31T07:00:00.000Z",
+			"post_to_at": "2027-05-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-10-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Half Price Paintball Entry"
 		},
 		{
@@ -582,10 +583,10 @@
 			"is_featured": false,
 			"listings": { "set": ["29"] },
 			"post_from_at": "2026-10-01T07:00:00.000Z",
-			"post_to_at": "2026-05-31T07:00:00.000Z",
+			"post_to_at": "2027-05-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-10-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Dining Napoli"
 		},
 		{
@@ -596,10 +597,10 @@
 			"is_featured": false,
 			"listings": { "set": ["3"] },
 			"post_from_at": "2026-11-01T07:00:00.000Z",
-			"post_to_at": "2026-05-31T07:00:00.000Z",
+			"post_to_at": "2027-05-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-11-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Community Access Program"
 		},
 		{
@@ -610,10 +611,10 @@
 			"is_featured": false,
 			"listings": { "set": ["30"] },
 			"post_from_at": "2026-11-01T07:00:00.000Z",
-			"post_to_at": "2026-05-31T07:00:00.000Z",
+			"post_to_at": "2027-05-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-11-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Staycation Destination"
 		},
 		{
@@ -624,10 +625,10 @@
 			"is_featured": false,
 			"listings": { "set": ["31"] },
 			"post_from_at": "2026-11-01T07:00:00.000Z",
-			"post_to_at": "2026-05-31T07:00:00.000Z",
+			"post_to_at": "2027-05-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-11-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Romance Package"
 		},
 		{
@@ -638,10 +639,10 @@
 			"is_featured": false,
 			"listings": { "set": ["32"] },
 			"post_from_at": "2026-11-01T07:00:00.000Z",
-			"post_to_at": "2026-05-31T07:00:00.000Z",
+			"post_to_at": "2027-05-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-11-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Give the Perfect Gift for Any Occasion"
 		},
 		{
@@ -652,10 +653,10 @@
 			"is_featured": false,
 			"listings": { "set": ["34"] },
 			"post_from_at": "2026-11-01T07:00:00.000Z",
-			"post_to_at": "2026-05-31T07:00:00.000Z",
+			"post_to_at": "2027-05-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-11-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Leap Year Twilight Ticket at Camelback Mountain"
 		},
 		{
@@ -666,10 +667,10 @@
 			"is_featured": false,
 			"listings": { "set": ["34"] },
 			"post_from_at": "2026-11-01T07:00:00.000Z",
-			"post_to_at": "2026-05-31T07:00:00.000Z",
+			"post_to_at": "2027-05-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-11-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Locals and College Night at Camelback Mountain"
 		},
 		{
@@ -736,10 +737,10 @@
 			"is_featured": false,
 			"listings": { "set": ["34"] },
 			"post_from_at": "2026-12-01T07:00:00.000Z",
-			"post_to_at": "2026-05-31T07:00:00.000Z",
+			"post_to_at": "2027-05-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-12-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Midweek Stays at Camelback Lodge"
 		},
 		{
@@ -806,10 +807,10 @@
 			"is_featured": false,
 			"listings": { "set": ["56"] },
 			"post_from_at": "2026-06-01T07:00:00.000Z",
-			"post_to_at": "2026-05-31T07:00:00.000Z",
+			"post_to_at": "2027-05-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-06-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Brass Rail"
 		},
 		{
@@ -820,10 +821,10 @@
 			"is_featured": false,
 			"listings": { "set": ["57"] },
 			"post_from_at": "2026-06-01T07:00:00.000Z",
-			"post_to_at": "2026-05-31T07:00:00.000Z",
+			"post_to_at": "2027-05-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-06-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "2026 Summer Adventure Overnight Camp"
 		},
 		{
@@ -834,10 +835,10 @@
 			"is_featured": false,
 			"listings": { "set": ["69"] },
 			"post_from_at": "2026-06-01T07:00:00.000Z",
-			"post_to_at": "2026-05-31T07:00:00.000Z",
+			"post_to_at": "2027-05-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-06-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "2026 Summer Adventure Overnight Camp"
 		},
 		{
@@ -862,10 +863,10 @@
 			"is_featured": true,
 			"listings": { "set": ["96"] },
 			"post_from_at": "2026-07-01T07:00:00.000Z",
-			"post_to_at": "2026-05-31T07:00:00.000Z",
+			"post_to_at": "2027-05-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-07-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Book Early and Save"
 		},
 		{
@@ -879,7 +880,7 @@
 			"post_to_at": "2026-10-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-12-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Multi Night Stays"
 		},
 		{
@@ -890,10 +891,10 @@
 			"is_featured": false,
 			"listings": { "set": ["96"] },
 			"post_from_at": "2026-12-01T07:00:00.000Z",
-			"post_to_at": "2026-10-31T07:00:00.000Z",
+			"post_to_at": "2027-10-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-12-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Cinco Ninos"
 		},
 		{
@@ -904,10 +905,10 @@
 			"is_featured": false,
 			"listings": { "set": ["96"] },
 			"post_from_at": "2026-12-01T07:00:00.000Z",
-			"post_to_at": "2026-10-31T07:00:00.000Z",
+			"post_to_at": "2027-10-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-12-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Discount Group Bookings"
 		},
 		{
@@ -921,7 +922,7 @@
 			"post_to_at": "2026-10-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-12-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Spa Three-Month Day Pass Subscription"
 		},
 		{
@@ -935,7 +936,7 @@
 			"post_to_at": "2026-10-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-12-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Bonnie and Clyde Pub and Grill"
 		},
 		{
@@ -949,7 +950,7 @@
 			"post_to_at": "2026-10-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-12-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Big Black Grill"
 		},
 		{
@@ -1005,7 +1006,7 @@
 			"post_to_at": "2026-10-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-12-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Romance at The Inn"
 		},
 		{
@@ -1019,7 +1020,7 @@
 			"post_to_at": "2026-10-31T07:00:00.000Z",
 			"rank": { "set": "2" },
 			"redeem_from_at": "2026-12-01T07:00:00.000Z",
-			"redeem_to_at": "2026-05-31T07:00:00.000Z",
+			"redeem_to_at": "2027-05-31T07:00:00.000Z",
 			"title": "Friends Getaway"
 		},
 		{
@@ -1060,9 +1061,9 @@
 			"rank": { "set": "2" },
 			"is_featured": true,
 			"post_from_at": "2026-12-02T07:00:00.000Z",
-			"post_to_at": "2026-05-30T07:00:00.000Z",
+			"post_to_at": "2027-05-30T07:00:00.000Z",
 			"redeem_from_at": "2026-12-11T07:00:00.000Z",
-			"redeem_to_at": "2026-05-30T07:00:00.000Z",
+			"redeem_to_at": "2027-05-30T07:00:00.000Z",
 			"description": "Lorem ipsum dolor sit amet, Settle in and save on 5+ consecutive nights. Book by Monday,May 27, 2026. Minimum stay 5+ nights at hotels, 7+ nights at resorts.\nAvailable at participating properties in the U.S., Canada, Caribbean and Latin America only.\n\nUnlock amazing benefits. Join Marriott Bonvoy™.\nHow to Book\nBe sure that the Promotional Code appears in the Corporate/Promotional code box when making your online reservation, or call 1-800-228-9290 and ask for the promotional code. For toll-free numbers outside the US please visit Global Reservation Numbers\n",
 			"title": "Save on 10+ Ipsum",
 			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp",

--- a/data/offers_automated.json
+++ b/data/offers_automated.json
@@ -17,6 +17,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3"
 				]
@@ -50,6 +51,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -80,6 +82,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"4",
 					"2"
@@ -108,6 +111,11 @@
 					"3",
 					"2",
 					"4"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -167,6 +175,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3"
 				]
@@ -195,6 +204,11 @@
 					"4"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -215,6 +229,11 @@
 			"title": "Weekend Getaway Special",
 			"description": "Enjoy non-stop gaming action and the relaxing four-season pool. This package includes a $100 dining credit to Lucky 8 Noodle and Sushi Bar! Available:  Seven days a week.Call or visit website for pricing.",
 			"categories": {
+				"set": [
+					"1"
+				]
+			},
+			"channels": {
 				"set": [
 					"1"
 				]
@@ -265,6 +284,7 @@
 			"description": "Enjoy non-stop gaming action and the relaxing four-season pool. This package includes a $100 dining credit to Lucky 8 Noodle and Sushi Bar! Available:  Seven days a week.Call or visit website for pricing.",
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -292,6 +312,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"4",
 					"3"
@@ -377,6 +398,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -396,6 +422,11 @@
 			"categories": {
 				"set": [
 					"2"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -463,6 +494,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -505,6 +537,7 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"2",
 					"3"
@@ -531,6 +564,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"2",
 					"3"
@@ -614,6 +648,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -648,6 +683,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"4"
 				]
@@ -671,6 +707,11 @@
 				"set": [
 					"3",
 					"2"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -700,6 +741,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -726,6 +768,11 @@
 				"set": [
 					"2",
 					"4",
+					"1"
+				]
+			},
+			"channels": {
+				"set": [
 					"1"
 				]
 			},
@@ -783,6 +830,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -806,6 +854,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -828,6 +877,7 @@
 			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp",
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7",
 					"4"
@@ -853,6 +903,7 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"3"
 				]
@@ -920,6 +971,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -949,6 +1001,11 @@
 					"4"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -973,6 +1030,11 @@
 			"title": "Members-Only Deal",
 			"description": " Now is a great time to introduce your family and friends to the world of paintball. Offer includes entry to the  paintball fields, a paintball gun rental, goggles facemask rental, unlimited N2 air fills, free parking, professional paintball referees, as well as all day play. Available: June 14, August 18, September 29, October 13 an 14 Cost:  $21.50 person with pre-registration discount, $42.99 person on game day. Ages 10 and up. ",
 			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -991,6 +1053,11 @@
 			"categories": {
 				"set": [
 					"3"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -1015,6 +1082,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7"
 				]
@@ -1100,6 +1168,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"2",
 					"4"
@@ -1129,6 +1198,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -1150,6 +1224,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3"
 				]
@@ -1174,6 +1249,11 @@
 					"4",
 					"3",
 					"2"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -1277,6 +1357,7 @@
 			"title": "Date Night at Lucky 8",
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -1313,6 +1394,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"2",
 					"4"
@@ -1367,6 +1449,11 @@
 			"categories": {
 				"set": [
 					"4",
+					"1"
+				]
+			},
+			"channels": {
+				"set": [
 					"1"
 				]
 			},
@@ -1427,6 +1514,7 @@
 			"title": "Birthday Bonus Package",
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"2"
 				]
@@ -1460,6 +1548,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7"
 				]
@@ -1525,6 +1614,11 @@
 					"4"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -1551,6 +1645,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -1574,6 +1669,11 @@
 				"set": [
 					"3",
 					"2",
+					"1"
+				]
+			},
+			"channels": {
+				"set": [
 					"1"
 				]
 			},
@@ -1630,6 +1730,11 @@
 			},
 			"title": "Fall Foliage Getaway",
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -1680,6 +1785,11 @@
 			},
 			"title": "Adventure Pass Offer",
 			"description": " Time to drop the books and hit the fields. All students are invited to play paintball for half price. That's right, all day paintball fun at half the price. Don't miss out on this limited time paintball offer!Every person that makes advance reservations and is paid in full at least 24 hours in advance will receive 100 free paintballs. 2026:  January 6, 7; February 3, 4, 24, 25; March 25, 26, 27, 28, 29, 30; April 1, 2, 3, 4, 5.Cost:$20.99 person with pre-registration discount. $41.99 person on game day. Ages 10 and up. Must have a valid student ID. Call to pre-register. ",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"rank": {
 				"set": "1"
 			},
@@ -1700,6 +1810,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -1780,6 +1891,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"3",
 					"4"
@@ -1832,6 +1944,11 @@
 			"title": "Weekend Getaway Special",
 			"description": "thank you to First Responders and Veterans for their service. Stop by and enjoy 10% off food purchases. Wednesday through Saturday Cost:  Varies by food item. Wednesdays and Thursdays from 4-8 p.m. and Fridays and Saturdays from 4-9 p.m. Proof of service is required. Cannot be combined with other offers.",
 			"weburl": "http://www.4thstreetmarket.com",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"1"
@@ -1905,6 +2022,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3"
 				]
@@ -1963,6 +2081,7 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -1987,6 +2106,11 @@
 					"4",
 					"1",
 					"3"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -2049,6 +2173,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"4"
 				]
@@ -2077,6 +2202,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -2106,6 +2232,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"4"
 				]
@@ -2134,6 +2261,11 @@
 					"1",
 					"2",
 					"4"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -2189,6 +2321,11 @@
 			"title": "Stay and Save Bundle",
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -2223,6 +2360,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"7"
 				]
@@ -2257,6 +2395,11 @@
 					"3"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -2287,6 +2430,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"7"
 				]
@@ -2313,6 +2457,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -2342,6 +2487,7 @@
 			"title": "Golf and Stay Package",
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"4"
 				]
@@ -2374,6 +2520,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3",
 					"7"
@@ -2402,6 +2549,11 @@
 					"3"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -2426,6 +2578,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"2"
 				]
@@ -2458,6 +2611,11 @@
 				"set": [
 					"4",
 					"3"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"rank": {
@@ -2544,6 +2702,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -2576,6 +2735,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3",
 					"2"
@@ -2629,6 +2789,11 @@
 					"3"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"1"
@@ -2654,6 +2819,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"7"
 				]
@@ -2685,6 +2851,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -2711,6 +2878,7 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -2741,6 +2909,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -2762,6 +2935,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -2830,6 +3004,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -2875,6 +3050,7 @@
 			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp",
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"4"
 				]
@@ -2900,6 +3076,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"7"
 				]
@@ -2930,6 +3107,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -2958,6 +3136,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"4"
 				]
@@ -2982,6 +3161,11 @@
 			"categories": {
 				"set": [
 					"2"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -3067,6 +3251,11 @@
 					"4"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -3132,6 +3321,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3"
 				]
@@ -3199,6 +3389,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -3263,6 +3458,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"7",
 					"2"
@@ -3356,6 +3552,11 @@
 					"4"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -3405,6 +3606,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -3431,6 +3637,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -3663,6 +3870,7 @@
 			"title": "Buy One Get One Half Off",
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -3684,6 +3892,7 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"7"
 				]
@@ -3704,6 +3913,7 @@
 			"description": "Enjoy non-stop gaming action and the relaxing four-season pool. This package includes a $100 dining credit to Lucky 8 Noodle and Sushi Bar! Available:  Seven days a week.Call or visit website for pricing.",
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -3762,6 +3972,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -3789,6 +4004,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"4"
 				]
@@ -3839,6 +4055,7 @@
 			"weburl": "https://www.marriott.com/offers/spa-retreats-package-off-88552/tussp-jw-marriott-tucson-starr-pass-resort-and-spa?propertycode=tussp",
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"7"
 				]
@@ -3864,6 +4081,7 @@
 			"description": "This is my 4th Street Offer!\nCome and get it!",
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -3914,6 +4132,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"7"
 				]
@@ -3936,6 +4155,11 @@
 			"title": "Spa Day Special",
 			"description": "thank you to First Responders and Veterans for their service. Stop by and enjoy 10% off food purchases. Wednesday through Saturday Cost:  Varies by food item. Wednesdays and Thursdays from 4-8 p.m. and Fridays and Saturdays from 4-9 p.m. Proof of service is required. Cannot be combined with other offers.",
 			"weburl": "http://www.4thstreetmarket.com",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -3962,6 +4186,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -3990,6 +4215,11 @@
 					"1"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -4006,6 +4236,7 @@
 			"description": " Time to drop the books and hit the fields. All students are invited to play paintball for half price. That's right, all day paintball fun at half the price. Don't miss out on this limited time paintball offer!Every person that makes advance reservations and is paid in full at least 24 hours in advance will receive 100 free paintballs. 2026:  January 6, 7; February 3, 4, 24, 25; March 25, 26, 27, 28, 29, 30; April 1, 2, 3, 4, 5.Cost:$20.99 person with pre-registration discount. $41.99 person on game day. Ages 10 and up. Must have a valid student ID. Call to pre-register. ",
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"2"
 				]
@@ -4086,6 +4317,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"4",
 					"2"
@@ -4198,6 +4430,11 @@
 					"1"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -4212,6 +4449,11 @@
 				"set": "13"
 			},
 			"title": "Winter Wonderland Package",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -4234,6 +4476,11 @@
 					"2",
 					"1",
 					"3"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -4273,6 +4520,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"4",
 					"2"
@@ -4329,6 +4577,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"4"
 				]
@@ -4356,6 +4605,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"2",
 					"3"
@@ -4459,6 +4709,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3",
 					"7"
@@ -4488,6 +4739,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -4513,6 +4765,11 @@
 					"1"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -4529,6 +4786,7 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3"
 				]
@@ -4558,6 +4816,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"2",
 					"4"
@@ -4586,6 +4845,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"4",
 					"3"
@@ -4617,6 +4877,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -4677,6 +4938,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"3",
 					"4"
@@ -4740,6 +5002,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"2",
 					"4"
@@ -4762,6 +5025,7 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -4810,6 +5074,7 @@
 			"description": "Enjoy non-stop gaming action and the relaxing four-season pool. This package includes a $100 dining credit to Lucky 8 Noodle and Sushi Bar! Available:  Seven days a week.Call or visit website for pricing.",
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -4831,6 +5096,7 @@
 			"description": "Get in the holiday spirit and enjoy Winterfest.  Stay in one of the spacious and charming queen rooms for two nights. Winterfest can be your one stop to get into the festive spirit. Listen to Christmas carols, visit the beautifully-decorated historic homes, shop in town, and take in the spirit of Christmas!  Rates start at $109 night, based on double occupancy, two-night minimum; includes tax.",
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"3",
 					"2"
@@ -4891,6 +5157,7 @@
 			"description": "Sseasonal equipment rentals are perfect for those not ready to invest in their own equipment, or families with young and fast-growing children. Grab your gear once and it's yours to keep for the whole season! No more waiting in rental line, just more time in the great outdoors. $279 includes skis snowboard, boots, bindings, and poles.",
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -4922,6 +5189,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"2",
 					"7"
@@ -4959,6 +5227,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -4987,6 +5256,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -5044,6 +5314,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"4"
 				]
@@ -5092,6 +5363,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"4"
 				]
@@ -5119,6 +5391,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"4"
 				]
@@ -5152,6 +5425,11 @@
 					"1"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -5178,6 +5456,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"7"
 				]
@@ -5226,6 +5505,11 @@
 					"1",
 					"3",
 					"4"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -5286,6 +5570,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"3",
 					"2"
@@ -5319,6 +5604,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"7",
 					"3"
@@ -5343,6 +5629,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"4",
 					"2"
@@ -5365,6 +5652,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3"
 				]
@@ -5430,6 +5718,11 @@
 					"4"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -5478,6 +5771,7 @@
 			"weburl": "https://www.marriott.com/offers/spa-retreats-package-off-88552/tussp-jw-marriott-tucson-starr-pass-resort-and-spa?propertycode=tussp",
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7"
 				]
@@ -5496,6 +5790,11 @@
 			"categories": {
 				"set": [
 					"3"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -5522,6 +5821,11 @@
 			"categories": {
 				"set": [
 					"2",
+					"1"
+				]
+			},
+			"channels": {
+				"set": [
 					"1"
 				]
 			},
@@ -5585,6 +5889,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"7"
 				]
@@ -5634,6 +5939,7 @@
 			"weburl": "https://www.marriott.com/offers/spa-retreats-package-off-88552/tussp-jw-marriott-tucson-starr-pass-resort-and-spa?propertycode=tussp",
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"2",
 					"4"
@@ -5666,6 +5972,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -5722,6 +6029,11 @@
 			},
 			"title": "Grand Opening Special",
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -5747,6 +6059,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"2"
 				]
@@ -5812,6 +6125,11 @@
 			},
 			"title": "Summer Splash Savings",
 			"weburl": "http://www.4thstreetmarket.com",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -5837,6 +6155,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3"
 				]
@@ -5920,6 +6239,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"7",
 					"2"
@@ -5949,6 +6269,7 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -5976,6 +6297,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"2"
 				]
@@ -5997,6 +6319,11 @@
 			},
 			"title": "Buy One Get One Half Off",
 			"description": "Enjoy non-stop gaming action and the relaxing four-season pool. This package includes a $100 dining credit to Lucky 8 Noodle and Sushi Bar! Available:  Seven days a week.Call or visit website for pricing.",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -6025,6 +6352,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -6107,6 +6435,11 @@
 					"1"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -6165,6 +6498,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"2"
 				]
@@ -6188,6 +6522,11 @@
 				"set": [
 					"2",
 					"4"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -6217,6 +6556,11 @@
 			"categories": {
 				"set": [
 					"4"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -6283,6 +6627,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"3"
 				]
@@ -6312,6 +6657,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"2",
 					"3"
@@ -6410,6 +6756,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -6434,6 +6781,11 @@
 					"3"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -6451,6 +6803,11 @@
 				"set": [
 					"3",
 					"2",
+					"1"
+				]
+			},
+			"channels": {
+				"set": [
 					"1"
 				]
 			},
@@ -6508,6 +6865,11 @@
 					"4"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -6527,6 +6889,11 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp",
 			"categories": {
+				"set": [
+					"1"
+				]
+			},
+			"channels": {
 				"set": [
 					"1"
 				]
@@ -6714,6 +7081,11 @@
 					"4"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -6728,6 +7100,11 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp",
 			"categories": {
+				"set": [
+					"1"
+				]
+			},
+			"channels": {
 				"set": [
 					"1"
 				]
@@ -6750,6 +7127,11 @@
 					"1",
 					"4",
 					"3"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -6803,6 +7185,11 @@
 					"1"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"tags": {
 				"set": [
 					"2"
@@ -6827,6 +7214,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -6855,6 +7243,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3",
 					"2"
@@ -6878,6 +7267,11 @@
 				"set": [
 					"4",
 					"3"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -6943,6 +7337,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -6970,6 +7365,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7",
 					"4"
@@ -7023,6 +7419,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7"
 				]
@@ -7061,6 +7458,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -7126,6 +7524,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"7",
 					"2"
@@ -7192,6 +7591,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -7216,6 +7616,11 @@
 			"title": "Anniversary Celebration Offer",
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"weburl": "https://www.marriott.com/offers/spa-retreats-package-off-88552/tussp-jw-marriott-tucson-starr-pass-resort-and-spa?propertycode=tussp",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -7244,6 +7649,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -7305,6 +7711,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3"
 				]
@@ -7359,6 +7766,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"3",
 					"2"
@@ -7391,6 +7799,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"2",
 					"7"
@@ -7412,6 +7821,7 @@
 			"title": "Grand Opening Special",
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3",
 					"7"
@@ -7444,6 +7854,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"3"
 				]
@@ -7481,6 +7892,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7",
 					"4"
@@ -7507,6 +7919,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"3",
 					"4"
@@ -7618,6 +8031,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -7645,6 +8059,11 @@
 				"set": [
 					"3",
 					"2"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -7770,6 +8189,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"4"
 				]
@@ -7824,6 +8244,11 @@
 					"3"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -7870,6 +8295,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -7892,6 +8322,7 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3"
 				]
@@ -7921,6 +8352,11 @@
 			"categories": {
 				"set": [
 					"3"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -7955,6 +8391,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -7983,6 +8424,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"2",
 					"4"
@@ -8121,6 +8563,11 @@
 					"1"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"1"
@@ -8151,6 +8598,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"2"
 				]
@@ -8200,6 +8648,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"2"
 				]
@@ -8285,6 +8734,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"2",
 					"4"
@@ -8318,6 +8768,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7",
 					"4"
@@ -8347,6 +8798,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -8371,6 +8823,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"4"
 				]
@@ -8396,6 +8849,11 @@
 				"set": [
 					"2",
 					"3"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -8428,6 +8886,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -8480,6 +8939,11 @@
 			"categories": {
 				"set": [
 					"4"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -8540,6 +9004,7 @@
 			"description": " Celebrate your love any day of the week when you book a romance special! A beautiful floral arrangement from Gorgeous Floral, chocolate from Moka Origins, and a bottle of bubbly will be in your room upon arrival! Enjoy some time reconnecting by the fire, or take a stroll through the woods before enjoying a sumptuous dinner. Awake refreshed and enjoy a delicious breakfast. February is the perfect month for an escape! Available: Seven days a week Price varies depending upon your choice of accommodation. Please call to book this getaway. Pricing is based on double occupancy. No other discounts can be applied. ",
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3"
 				]
@@ -8563,6 +9028,11 @@
 			},
 			"title": "Early Bird Discount",
 			"description": "Enjoy non-stop gaming action and the relaxing four-season pool. This package includes a $100 dining credit to Lucky 8 Noodle and Sushi Bar! Available:  Seven days a week.Call or visit website for pricing.",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -8586,6 +9056,11 @@
 				"set": [
 					"1",
 					"2"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -8613,6 +9088,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -8639,6 +9115,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"4"
 				]
@@ -8667,6 +9144,11 @@
 			},
 			"title": "Senior Season Pass",
 			"weburl": "https://www.marriott.com/offers/spa-retreats-package-off-88552/tussp-jw-marriott-tucson-starr-pass-resort-and-spa?propertycode=tussp",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -8695,6 +9177,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -8773,6 +9256,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"2"
 				]
@@ -8803,6 +9287,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3"
 				]
@@ -8834,6 +9319,11 @@
 				"set": [
 					"3",
 					"2"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -8889,6 +9379,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"7"
 				]
@@ -8917,6 +9408,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -8948,6 +9440,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"2",
 					"3"
@@ -9003,6 +9496,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"4"
 				]
@@ -9031,6 +9525,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -9048,6 +9547,11 @@
 			"title": "Winter Wonderland Package",
 			"description": "thank you to First Responders and Veterans for their service. Stop by and enjoy 10% off food purchases. Wednesday through Saturday Cost:  Varies by food item. Wednesdays and Thursdays from 4-8 p.m. and Fridays and Saturdays from 4-9 p.m. Proof of service is required. Cannot be combined with other offers.",
 			"weburl": "http://www.4thstreetmarket.com",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -9102,6 +9606,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -9136,6 +9645,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7"
 				]
@@ -9166,6 +9676,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -9195,6 +9706,11 @@
 					"2",
 					"1",
 					"4"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -9229,6 +9745,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -9282,6 +9799,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"4",
 					"2"
@@ -9366,6 +9884,7 @@
 			"description": " Now is a great time to introduce your family and friends to the world of paintball. Offer includes entry to the  paintball fields, a paintball gun rental, goggles facemask rental, unlimited N2 air fills, free parking, professional paintball referees, as well as all day play. Available: June 14, August 18, September 29, October 13 an 14 Cost:  $21.50 person with pre-registration discount, $42.99 person on game day. Ages 10 and up. ",
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"2"
 				]
@@ -9394,6 +9913,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -9501,6 +10021,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"2"
 				]
@@ -9532,6 +10053,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -9556,6 +10078,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"2"
 				]
@@ -9581,6 +10104,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -9597,6 +10121,7 @@
 			"description": "Get the best deal on the Summer Adventure Overnight Camp! Stay the week and explore the mountain day and night. Overnight campers experience the same adventures of the day campers, but have the added fun of spending their mornings and nights! Experience after dark with night hiking, stargazing and sitting around the campfire telling stories and roasting smores! ",
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"7"
 				]
@@ -9628,6 +10153,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -9659,6 +10185,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"4"
 				]
@@ -9690,6 +10217,7 @@
 			"description": " Give yourself a chance to experience romance. Enjoy a romantic atmosphere as we take it the next level with the perfect package to share with your loved one. Offer includes three days and two nights, romantic decoration in the room, one bottle of wine, desserts, appetizer and one breakfast per couple (chef's selection.) Available:  Seven days a week Call for pricing. Restrictions may apply. Subject to availability ",
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7",
 					"4"
@@ -9724,6 +10252,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -9808,6 +10337,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"2",
 					"4"
@@ -9835,6 +10365,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"2"
 				]
@@ -9866,6 +10397,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -9892,6 +10424,7 @@
 			"description": "Enjoy non-stop gaming action and the relaxing four-season pool. This package includes a $100 dining credit to Lucky 8 Noodle and Sushi Bar! Available:  Seven days a week.Call or visit website for pricing.",
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -9944,6 +10477,7 @@
 			"description": " Life is a journey. Strength is one quality it takes to skillfully move through this adventure, doing everything you need to experience a deep sense of fulfillment and cultivate everlasting freedom. This weekend combines the brilliance of yoga its strengthening, lengthening, opening, expanding, and relaxing consequences with the magic of a retreat format that will restore, revitalize, and help you reconnect. Immerse yourself into the study and practice sessions with Luke this weekend, and explore how to create a sustainable environment on all levels through a practice designed to meet you where you are. Your strong and resilient self awaits! Look forward to seeing you at this special retreat. vailable:  Friday through Sunday Visit website for call for pricing.",
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -9971,6 +10505,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -10022,6 +10557,11 @@
 					"4"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -10044,6 +10584,11 @@
 			"categories": {
 				"set": [
 					"4"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -10071,6 +10616,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"3",
 					"2"
@@ -10107,6 +10653,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -10165,6 +10712,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -10191,6 +10739,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -10221,6 +10770,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"4"
 				]
@@ -10250,6 +10800,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -10277,6 +10828,11 @@
 			"categories": {
 				"set": [
 					"2"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -10366,6 +10922,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -10423,6 +10980,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7",
 					"3"
@@ -10453,6 +11011,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"3"
 				]
@@ -10479,6 +11038,7 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"4",
 					"3"
@@ -10539,6 +11099,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -10672,6 +11233,11 @@
 			"title": "Stay and Save Bundle",
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"weburl": "http://www.4thstreetmarket.com",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -10745,6 +11311,11 @@
 			},
 			"title": "Leap Year Twilight Ticket at Camelback Mountain",
 			"description": "Calling all locals with the zip code starting in 183  and college students to Camelback Mountain on Tuesday nights! Every Tuesday night starting at 3 p.m., hit the slopes with a twilight lift ticket for only $39. Available:  Tuesday Cost:  $39 person. Offer valid only for college students and locals in the 183 zip code. This offer must be purchased onsite at Guest Services. Present your college ID, drivers license, or local school ID to redeem your exclusive discount and parking pass. Plus you will receive free parking in lots 5, 7, 8 and 9. This offer is valid every Tuesday night, blackout dates apply (February 20, 2026).",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"tags": {
 				"set": [
 					"3"
@@ -10769,6 +11340,11 @@
 				"set": [
 					"3",
 					"4"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -10800,6 +11376,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -10829,6 +11406,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -10852,6 +11430,11 @@
 			"categories": {
 				"set": [
 					"2",
+					"1"
+				]
+			},
+			"channels": {
+				"set": [
 					"1"
 				]
 			},
@@ -10919,6 +11502,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -10949,6 +11533,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3"
 				]
@@ -11005,6 +11590,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"3"
 				]
@@ -11065,6 +11651,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -11095,6 +11682,11 @@
 					"3"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -11118,6 +11710,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -11143,6 +11736,11 @@
 					"3",
 					"1",
 					"2"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -11178,6 +11776,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -11196,6 +11795,7 @@
 			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp",
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -11223,6 +11823,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -11245,6 +11850,11 @@
 					"1"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -11258,6 +11868,11 @@
 			},
 			"title": "Date Night Getaway",
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -11341,6 +11956,11 @@
 					"3"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -11369,6 +11989,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -11399,6 +12020,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7"
 				]
@@ -11425,6 +12047,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -11457,6 +12080,11 @@
 					"1"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -11481,6 +12109,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -11503,6 +12132,7 @@
 			"description": "Enjoy non-stop gaming action and the relaxing four-season pool. This package includes a $100 dining credit to Lucky 8 Noodle and Sushi Bar! Available:  Seven days a week.Call or visit website for pricing.",
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"2"
 				]
@@ -11529,6 +12159,11 @@
 					"1",
 					"4",
 					"3"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -11559,6 +12194,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -11584,6 +12220,11 @@
 					"3",
 					"4",
 					"2"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -11668,6 +12309,11 @@
 					"4"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -11732,6 +12378,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -11758,6 +12405,7 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -11787,6 +12435,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -11812,6 +12461,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -11850,6 +12500,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3",
 					"2"
@@ -11906,6 +12557,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -11936,6 +12588,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7"
 				]
@@ -11961,6 +12614,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"4",
 					"3"
@@ -12022,6 +12676,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -12060,6 +12715,11 @@
 			"categories": {
 				"set": [
 					"4"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -12108,6 +12768,11 @@
 			},
 			"title": "Couples Getaway Package",
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"tags": {
 				"set": [
 					"3",
@@ -12137,6 +12802,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -12170,6 +12836,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3",
 					"4"
@@ -12198,6 +12865,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -12222,6 +12894,7 @@
 			"description": "Get in the holiday spirit and enjoy Winterfest.  Stay in one of the spacious and charming queen rooms for two nights. Winterfest can be your one stop to get into the festive spirit. Listen to Christmas carols, visit the beautifully-decorated historic homes, shop in town, and take in the spirit of Christmas!  Rates start at $109 night, based on double occupancy, two-night minimum; includes tax.",
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -12248,6 +12921,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"7",
 					"2"
@@ -12275,6 +12949,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"3",
 					"2"
@@ -12325,6 +13000,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -12384,6 +13060,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3",
 					"4"
@@ -12447,6 +13124,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -12468,6 +13146,7 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -12500,6 +13179,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -12526,6 +13206,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -12548,6 +13229,11 @@
 			},
 			"title": "Day Trip Special",
 			"description": "thank you to First Responders and Veterans for their service. Stop by and enjoy 10% off food purchases. Wednesday through Saturday Cost:  Varies by food item. Wednesdays and Thursdays from 4-8 p.m. and Fridays and Saturdays from 4-9 p.m. Proof of service is required. Cannot be combined with other offers.",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -12578,6 +13264,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"4"
 				]
@@ -12599,6 +13286,7 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -12626,6 +13314,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"2",
 					"3"
@@ -12650,6 +13339,7 @@
 			"description": "Its time to relax, refresh and rejuvenate! From hiking, biking and the unforgettable treetop adventure course to nightly campfires and marshmallow roasts, save on the freshest moments of the season. So, whether serenity or high octane adventure is on the agenda, the ideal place for an unforgettable springtime escape. The Spring Renewal Bed and Breakfast offer includes delicious daily breakfast, AAA 4-Diamond accommodations with up to 10% off room rates, $100 in resort credits (stay two nights get $60 in resort credits, stay three nights get $100 in resort credits.) See website for details. Terms and conditions apply. Based on availability. Must cancel seven days prior to arrival to receive full refund. No credit or refund will be issued for any unused portions of this package. Travel window: 02 26-05 23 2026. All activities are weather dependent and may require reservations and or a fee.",
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3"
 				]
@@ -12839,6 +13529,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7"
 				]
@@ -12870,6 +13561,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"7"
 				]
@@ -12906,6 +13598,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -12956,6 +13649,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -13003,6 +13697,7 @@
 			"description": "This is my 4th Street Offer!\nCome and get it!",
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -13036,6 +13731,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -13059,6 +13755,11 @@
 				"set": [
 					"3",
 					"4"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"rank": {
@@ -13112,6 +13813,11 @@
 					"4"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -13139,6 +13845,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3"
 				]
@@ -13167,6 +13874,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"2",
 					"7"
@@ -13196,6 +13904,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -13220,6 +13933,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -13281,6 +13995,11 @@
 					"4"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -13328,6 +14047,7 @@
 			"weburl": "https://www.marriott.com/offers/spa-retreats-package-off-88552/tussp-jw-marriott-tucson-starr-pass-resort-and-spa?propertycode=tussp",
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3",
 					"7"
@@ -13368,6 +14088,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"4",
 					"3"
@@ -13391,6 +14112,7 @@
 			"description": " Now is a great time to introduce your family and friends to the world of paintball. Offer includes entry to the  paintball fields, a paintball gun rental, goggles facemask rental, unlimited N2 air fills, free parking, professional paintball referees, as well as all day play. Available: June 14, August 18, September 29, October 13 an 14 Cost:  $21.50 person with pre-registration discount, $42.99 person on game day. Ages 10 and up. ",
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"2",
 					"7"
@@ -13421,6 +14143,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7"
 				]
@@ -13439,6 +14162,7 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7",
 					"3"
@@ -13463,6 +14187,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3",
 					"7"
@@ -13519,6 +14244,11 @@
 					"3"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -13546,6 +14276,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"4"
 				]
@@ -13601,6 +14332,7 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7"
 				]
@@ -13627,6 +14359,11 @@
 					"3"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -13645,6 +14382,11 @@
 				"set": "36"
 			},
 			"title": "Local Explorer Deal",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -13691,6 +14433,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -13717,6 +14460,11 @@
 			},
 			"title": "My 4th Street Basic Offer",
 			"description": "thank you to First Responders and Veterans for their service. Stop by and enjoy 10% off food purchases. Wednesday through Saturday Cost:  Varies by food item. Wednesdays and Thursdays from 4-8 p.m. and Fridays and Saturdays from 4-9 p.m. Proof of service is required. Cannot be combined with other offers.",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -13746,6 +14494,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -13893,6 +14642,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -13925,6 +14679,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"7"
 				]
@@ -13956,6 +14711,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -13977,6 +14733,11 @@
 			"categories": {
 				"set": [
 					"4"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -14057,6 +14818,11 @@
 					"3"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -14110,6 +14876,11 @@
 					"3"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -14134,6 +14905,11 @@
 			},
 			"title": "Last-Minute Deal",
 			"weburl": "https://www.marriott.com/offers/spa-retreats-package-off-88552/tussp-jw-marriott-tucson-starr-pass-resort-and-spa?propertycode=tussp",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"post_from_at": "2026-04-13T07:00:00.000Z",
 			"post_to_at": "2026-07-20T07:00:00.000Z",
 			"redeem_from_at": "2025-09-30T07:00:00.000Z",
@@ -14147,6 +14923,7 @@
 			"description": "Enjoy non-stop gaming action and the relaxing four-season pool. This package includes a $100 dining credit to Lucky 8 Noodle and Sushi Bar! Available:  Seven days a week.Call or visit website for pricing.",
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -14178,6 +14955,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"4"
 				]
@@ -14213,6 +14991,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -14239,6 +15018,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -14268,6 +15048,11 @@
 					"1",
 					"2",
 					"3"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -14324,6 +15109,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -14343,6 +15129,11 @@
 					"2",
 					"1",
 					"4"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -14369,6 +15160,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -14389,6 +15185,7 @@
 			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp",
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"7"
 				]
@@ -14414,6 +15211,11 @@
 			"title": "Winterfest Weekend",
 			"description": " Time to drop the books and hit the fields. All students are invited to play paintball for half price. That's right, all day paintball fun at half the price. Don't miss out on this limited time paintball offer!Every person that makes advance reservations and is paid in full at least 24 hours in advance will receive 100 free paintballs. 2026:  January 6, 7; February 3, 4, 24, 25; March 25, 26, 27, 28, 29, 30; April 1, 2, 3, 4, 5.Cost:$20.99 person with pre-registration discount. $41.99 person on game day. Ages 10 and up. Must have a valid student ID. Call to pre-register. ",
 			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -14517,6 +15319,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3",
 					"7"
@@ -14576,6 +15379,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"7"
 				]
@@ -14602,6 +15406,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3"
 				]
@@ -14635,6 +15440,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"2"
 				]
@@ -14663,6 +15469,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"4",
 					"2"
@@ -14691,6 +15498,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -14716,6 +15524,11 @@
 					"1",
 					"3",
 					"4"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -14774,6 +15587,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"2",
 					"3"
@@ -14802,6 +15616,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -14825,6 +15644,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -14852,6 +15672,11 @@
 			"title": "Kids Eat Free Promotion",
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"weburl": "https://www.marriott.com/offers/spa-retreats-package-off-88552/tussp-jw-marriott-tucson-starr-pass-resort-and-spa?propertycode=tussp",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"tags": {
 				"set": [
 					"3",
@@ -14940,6 +15765,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -14967,6 +15793,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"rank": {
 				"set": "1"
 			},
@@ -14990,6 +15821,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"4"
 				]
@@ -15050,6 +15882,11 @@
 					"1"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -15075,6 +15912,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -15107,6 +15945,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -15132,6 +15971,11 @@
 			},
 			"title": "Loyalty Rewards Offer",
 			"description": " Now is a great time to introduce your family and friends to the world of paintball. Offer includes entry to the  paintball fields, a paintball gun rental, goggles facemask rental, unlimited N2 air fills, free parking, professional paintball referees, as well as all day play. Available: June 14, August 18, September 29, October 13 an 14 Cost:  $21.50 person with pre-registration discount, $42.99 person on game day. Ages 10 and up. ",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"tags": {
 				"set": [
 					"3"
@@ -15158,6 +16002,11 @@
 					"4"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -15182,6 +16031,11 @@
 				"set": [
 					"3",
 					"4",
+					"1"
+				]
+			},
+			"channels": {
+				"set": [
 					"1"
 				]
 			},
@@ -15214,6 +16068,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -15242,6 +16097,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"7",
 					"4"
@@ -15291,6 +16147,7 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"4"
 				]
@@ -15315,6 +16172,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"4"
 				]
@@ -15349,6 +16207,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -15375,6 +16238,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7"
 				]
@@ -15404,6 +16268,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"4"
 				]
@@ -15431,6 +16296,11 @@
 					"4"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -15453,6 +16323,11 @@
 				"set": [
 					"4",
 					"3",
+					"1"
+				]
+			},
+			"channels": {
+				"set": [
 					"1"
 				]
 			},
@@ -15481,6 +16356,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"2"
 				]
@@ -15508,6 +16384,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -15542,6 +16419,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -15577,6 +16455,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"7",
 					"3"
@@ -15687,6 +16566,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"4"
 				]
@@ -15721,6 +16601,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"7",
 					"4"
@@ -15750,6 +16631,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -15780,6 +16662,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"1"
@@ -15798,6 +16685,11 @@
 			},
 			"title": "Summer Splash Savings",
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"is_featured": true,
 			"post_from_at": "2025-09-08T07:00:00.000Z",
 			"post_to_at": "2026-02-15T07:00:00.000Z",
@@ -15875,6 +16767,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"7",
 					"2"
@@ -15914,6 +16807,11 @@
 					"1"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -15939,6 +16837,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -15966,6 +16865,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -15994,6 +16894,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -16028,6 +16929,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"3"
 				]
@@ -16111,6 +17013,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -16139,6 +17042,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -16156,6 +17064,7 @@
 			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp",
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -16180,6 +17089,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -16208,6 +17118,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -16267,6 +17178,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -16296,6 +17208,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"4",
 					"7"
@@ -16320,6 +17233,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -16344,6 +17258,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -16376,6 +17291,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -16499,6 +17415,7 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"3"
 				]
@@ -16561,6 +17478,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7"
 				]
@@ -16589,6 +17507,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3"
 				]
@@ -16619,6 +17538,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -16705,6 +17625,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -16730,6 +17651,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7"
 				]
@@ -16757,6 +17679,11 @@
 			},
 			"title": "Festival Weekend Package",
 			"description": "Enjoy non-stop gaming action and the relaxing four-season pool. This package includes a $100 dining credit to Lucky 8 Noodle and Sushi Bar! Available:  Seven days a week.Call or visit website for pricing.",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -16833,6 +17760,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3"
 				]
@@ -16859,6 +17787,7 @@
 			"weburl": "https://www.marriott.com/offers/spa-retreats-package-off-88552/tussp-jw-marriott-tucson-starr-pass-resort-and-spa?propertycode=tussp",
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"7"
 				]
@@ -16891,6 +17820,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -16923,6 +17853,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -16987,6 +17918,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"3"
 				]
@@ -17040,6 +17972,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"2"
 				]
@@ -17072,6 +18005,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"2"
 				]
@@ -17108,6 +18042,11 @@
 					"4"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -17127,6 +18066,11 @@
 			},
 			"title": "Last-Minute Deal",
 			"description": " Time to drop the books and hit the fields. All students are invited to play paintball for half price. That's right, all day paintball fun at half the price. Don't miss out on this limited time paintball offer!Every person that makes advance reservations and is paid in full at least 24 hours in advance will receive 100 free paintballs. 2026:  January 6, 7; February 3, 4, 24, 25; March 25, 26, 27, 28, 29, 30; April 1, 2, 3, 4, 5.Cost:$20.99 person with pre-registration discount. $41.99 person on game day. Ages 10 and up. Must have a valid student ID. Call to pre-register. ",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -17158,6 +18102,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -17183,6 +18128,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7"
 				]
@@ -17216,6 +18162,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"2",
 					"4"
@@ -17249,6 +18196,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -17274,6 +18226,11 @@
 					"3"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -17294,6 +18251,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"4",
 					"2"
@@ -17315,6 +18273,11 @@
 			"title": "Margarita Mondays",
 			"description": " Book a full or half day of paintball for May 12and pay half-price admission. Available: Sunday Cost: Call (570) 669-9127 for pricing. ",
 			"weburl": "https://www.marriott.com/offers/spa-retreats-package-off-88552/tussp-jw-marriott-tucson-starr-pass-resort-and-spa?propertycode=tussp",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -17348,6 +18311,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -17404,6 +18368,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -17432,6 +18397,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -17456,6 +18422,11 @@
 					"1",
 					"4",
 					"3"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -17483,6 +18454,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -17516,6 +18488,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3",
 					"7"
@@ -17548,6 +18521,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -17599,6 +18573,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"tags": {
 				"set": [
 					"2"
@@ -17623,6 +18602,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"7",
 					"4"
@@ -17649,6 +18629,11 @@
 				"set": [
 					"3",
 					"4",
+					"1"
+				]
+			},
+			"channels": {
+				"set": [
 					"1"
 				]
 			},
@@ -17707,6 +18692,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"2"
 				]
@@ -17735,6 +18721,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7",
 					"3"
@@ -17760,6 +18747,11 @@
 			"categories": {
 				"set": [
 					"4"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"post_from_at": "2025-10-21T07:00:00.000Z",
@@ -17805,6 +18797,11 @@
 					"3"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -17836,6 +18833,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"7"
 				]
@@ -17864,6 +18862,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -17883,6 +18882,7 @@
 			"description": " Now is a great time to introduce your family and friends to the world of paintball. Offer includes entry to the  paintball fields, a paintball gun rental, goggles facemask rental, unlimited N2 air fills, free parking, professional paintball referees, as well as all day play. Available: June 14, August 18, September 29, October 13 an 14 Cost:  $21.50 person with pre-registration discount, $42.99 person on game day. Ages 10 and up. ",
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -17906,6 +18906,7 @@
 			"description": "Spring into Summer with rates staring at $279, there is no reason to wait to book your Summer getaway! Reserve  Spring into Summer offer by March 31, 2026 and receive a resort credit to enhance your stay. The offer includes AAA four-diamond accommodations, daily breakfast, up to $250 daily resort credits (stay two nights and received $80, stay three nights and receive $150, stay four nights and receive $250.)Call (855) 345-7759 for available rates or see website for details. Book by March 31, 2026.",
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"2"
 				]
@@ -18083,6 +19084,11 @@
 					"1"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"1"
@@ -18110,6 +19116,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3"
 				]
@@ -18171,6 +19178,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -18201,6 +19209,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -18225,6 +19234,11 @@
 					"1",
 					"3",
 					"2"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -18285,6 +19299,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -18312,6 +19327,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"post_from_at": "2025-08-20T07:00:00.000Z",
 			"post_to_at": "2026-03-20T07:00:00.000Z",
 			"redeem_from_at": "2026-02-02T07:00:00.000Z",
@@ -18332,6 +19352,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"2"
 				]
@@ -18408,6 +19429,7 @@
 			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp",
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"2",
 					"4"
@@ -18438,6 +19460,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -18461,6 +19488,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -18534,6 +19562,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"7"
 				]
@@ -18559,6 +19588,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -18595,6 +19625,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"2",
 					"4"
@@ -18619,6 +19650,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -18645,6 +19677,11 @@
 			},
 			"title": "My 4th Street Basic Offer",
 			"description": "This is my 4th Street Offer!\nCome and get it!",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -18698,6 +19735,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -18729,6 +19767,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7",
 					"3"
@@ -18789,6 +19828,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -18829,6 +19869,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -18875,6 +19916,7 @@
 			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp",
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -18932,6 +19974,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -18986,6 +20029,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -19018,6 +20066,7 @@
 			"title": "Limited Time Promotion",
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -19043,6 +20092,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"2",
 					"3"
@@ -19075,6 +20125,11 @@
 					"4"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -19097,6 +20152,7 @@
 			"title": "Spring Getaway Special - 15% Off",
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"2",
 					"7"
@@ -19130,6 +20186,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -19159,6 +20216,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3",
 					"4"
@@ -19279,6 +20337,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -19309,6 +20368,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3",
 					"7"
@@ -19342,6 +20402,7 @@
 			"description": "This is my 4th Street Offer!\nCome and get it!",
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"4"
 				]
@@ -19379,6 +20440,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3"
 				]
@@ -19407,6 +20469,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -19481,6 +20544,7 @@
 			"description": "This is my 4th Street Offer!\nCome and get it!",
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -19542,6 +20606,11 @@
 					"3"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -19599,6 +20668,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -19627,6 +20697,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"4"
 				]
@@ -19655,6 +20726,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -19711,6 +20783,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3"
 				]
@@ -19742,6 +20815,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"7"
 				]
@@ -19768,6 +20842,11 @@
 					"3"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -19789,6 +20868,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -19808,6 +20888,7 @@
 			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp",
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -19842,6 +20923,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"7",
 					"2"
@@ -19872,6 +20954,11 @@
 					"4"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -19891,6 +20978,11 @@
 			"categories": {
 				"set": [
 					"4"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -19916,6 +21008,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3",
 					"2"
@@ -19978,6 +21071,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"post_from_at": "2025-11-24T07:00:00.000Z",
 			"post_to_at": "2026-05-30T07:00:00.000Z",
 			"redeem_from_at": "2024-11-10T07:00:00.000Z",
@@ -19991,6 +21089,7 @@
 			"description": "Enjoy non-stop gaming action and the relaxing four-season pool. This package includes a $100 dining credit to Lucky 8 Noodle and Sushi Bar! Available:  Seven days a week.Call or visit website for pricing.",
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3"
 				]
@@ -20022,6 +21121,11 @@
 					"1"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -20042,6 +21146,11 @@
 			"categories": {
 				"set": [
 					"4"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -20101,6 +21210,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"4",
 					"7"
@@ -20139,6 +21249,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -20199,6 +21310,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"4"
 				]
@@ -20221,6 +21333,7 @@
 			"description": " Time to drop the books and hit the fields. All students are invited to play paintball for half price. That's right, all day paintball fun at half the price. Don't miss out on this limited time paintball offer!Every person that makes advance reservations and is paid in full at least 24 hours in advance will receive 100 free paintballs. 2026:  January 6, 7; February 3, 4, 24, 25; March 25, 26, 27, 28, 29, 30; April 1, 2, 3, 4, 5.Cost:$20.99 person with pre-registration discount. $41.99 person on game day. Ages 10 and up. Must have a valid student ID. Call to pre-register. ",
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"4",
 					"7"
@@ -20252,6 +21365,11 @@
 			"title": "Adventure Pass Offer",
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -20271,6 +21389,11 @@
 			"categories": {
 				"set": [
 					"2"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -20298,6 +21421,11 @@
 			"categories": {
 				"set": [
 					"3"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -20353,6 +21481,11 @@
 					"1"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -20380,6 +21513,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"4"
 				]
@@ -20412,6 +21546,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -20439,6 +21574,11 @@
 				"set": [
 					"1",
 					"4"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -20489,6 +21629,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"2",
 					"7"
@@ -20517,6 +21658,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -20545,6 +21687,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"3",
 					"2"
@@ -20601,6 +21744,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7",
 					"4"
@@ -20625,6 +21769,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"1"
@@ -20646,6 +21795,11 @@
 					"4",
 					"3",
 					"2"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -20675,6 +21829,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"4",
 					"7"
@@ -20710,6 +21865,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -20738,6 +21894,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"2"
 				]
@@ -20762,6 +21919,11 @@
 			"categories": {
 				"set": [
 					"4"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -20790,6 +21952,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -20893,6 +22056,7 @@
 			"title": "Extended Stay Discount",
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -20920,6 +22084,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"7",
 					"4"
@@ -20951,6 +22116,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -21017,6 +22183,7 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -21097,6 +22264,11 @@
 					"1"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -21124,6 +22296,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3",
 					"2"
@@ -21144,6 +22317,11 @@
 			},
 			"title": "Holiday Celebration Package",
 			"description": "Enjoy non-stop gaming action and the relaxing four-season pool. This package includes a $100 dining credit to Lucky 8 Noodle and Sushi Bar! Available:  Seven days a week.Call or visit website for pricing.",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -21169,6 +22347,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7"
 				]
@@ -21192,6 +22371,11 @@
 					"4",
 					"2",
 					"3"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -21254,6 +22438,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -21286,6 +22471,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3"
 				]
@@ -21310,6 +22496,7 @@
 			"title": "Kids Eat Free Promotion",
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"4",
 					"7"
@@ -21375,6 +22562,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -21433,6 +22621,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -21521,6 +22710,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -21551,6 +22741,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3",
 					"2"
@@ -21579,6 +22770,7 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3"
 				]
@@ -21605,6 +22797,11 @@
 					"4"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -21629,6 +22826,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"7",
 					"3"
@@ -21659,6 +22857,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3"
 				]
@@ -21688,6 +22887,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -21709,6 +22913,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3"
 				]
@@ -21739,6 +22944,11 @@
 					"3"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -21758,6 +22968,11 @@
 			},
 			"title": "Loyalty Rewards Offer",
 			"weburl": "http://www.4thstreetmarket.com",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -21776,6 +22991,11 @@
 			"title": "Leap Year Twilight Ticket at Camelback Mountain",
 			"description": " Restaurant Week Includes:  Explore the more exotic flavors of the Republic of Mexico and enjoy a Taste of Mexico. Offer includes octopus taco (charcoal fired octopus arms, chipotle crema, blue corn tortilla, cabbage salpicon), squash blossom (tempura squash blossom on a salbut, topped with salsa ranchera, queso fresco and micro cilantro), Tuetano (skirt steak asada taco topped with bone marrow, salsa verde, onions and micro cilantro), duck mole (duck confit, puebla mole, crema, sesame seeds, queso fresco, onions cilantro), and fluke ceviche (medley sliced peppers, fluke, avocado, cranberry habanero gastrique on a tostada, all served on four inch tortilla or tostada. Available:  Sunday through Friday Cost:  $30 person.",
 			"weburl": "https://www.marriott.com/offers/spa-retreats-package-off-88552/tussp-jw-marriott-tucson-starr-pass-resort-and-spa?propertycode=tussp",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -21806,6 +23026,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"7"
 				]
@@ -21868,6 +23089,11 @@
 					"3"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"post_from_at": "2026-04-09T07:00:00.000Z",
 			"post_to_at": "2026-08-13T07:00:00.000Z",
 			"redeem_from_at": "2024-10-01T07:00:00.000Z",
@@ -21920,6 +23146,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"2"
 				]
@@ -22034,6 +23261,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -22064,6 +23292,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -22101,6 +23330,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -22128,6 +23358,11 @@
 				"set": [
 					"2",
 					"3"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -22160,6 +23395,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"2"
 				]
@@ -22209,6 +23445,7 @@
 			"description": "thank you to First Responders and Veterans for their service. Stop by and enjoy 10% off food purchases. Wednesday through Saturday Cost:  Varies by food item. Wednesdays and Thursdays from 4-8 p.m. and Fridays and Saturdays from 4-9 p.m. Proof of service is required. Cannot be combined with other offers.",
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -22228,6 +23465,7 @@
 			"description": "Enjoy non-stop gaming action and the relaxing four-season pool. This package includes a $100 dining credit to Lucky 8 Noodle and Sushi Bar! Available:  Seven days a week.Call or visit website for pricing.",
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"2"
 				]
@@ -22254,6 +23492,11 @@
 					"1"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -22271,6 +23514,11 @@
 			},
 			"title": "Family Fun Package",
 			"description": " Now is a great time to introduce your family and friends to the world of paintball. Offer includes entry to the  paintball fields, a paintball gun rental, goggles facemask rental, unlimited N2 air fills, free parking, professional paintball referees, as well as all day play. Available: June 14, August 18, September 29, October 13 an 14 Cost:  $21.50 person with pre-registration discount, $42.99 person on game day. Ages 10 and up. ",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -22366,6 +23614,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -22438,6 +23687,11 @@
 					"1"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -22460,6 +23714,7 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"4"
 				]
@@ -22484,6 +23739,11 @@
 			"categories": {
 				"set": [
 					"3"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -22539,6 +23799,7 @@
 			"description": "Restaurant Week Includes:  Stop by and spend $35 or more and receive $7 off. Available: Sunday through Friday Cost:Spend $35 or more.",
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -22634,6 +23895,11 @@
 					"4"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -22657,6 +23923,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"4"
 				]
@@ -22683,6 +23950,7 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -22708,6 +23976,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3",
 					"7"
@@ -22737,6 +24006,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"7",
 					"2"
@@ -22770,6 +24040,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"2"
 				]
@@ -22802,6 +24073,11 @@
 					"1"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -22825,6 +24101,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3"
 				]
@@ -22845,6 +24122,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"7",
 					"2"
@@ -22875,6 +24153,11 @@
 			"title": "Date Night at Lucky 8",
 			"description": " Now is a great time to introduce your family and friends to the world of paintball. Offer includes entry to the  paintball fields, a paintball gun rental, goggles facemask rental, unlimited N2 air fills, free parking, professional paintball referees, as well as all day play. Available: June 14, August 18, September 29, October 13 an 14 Cost:  $21.50 person with pre-registration discount, $42.99 person on game day. Ages 10 and up. ",
 			"weburl": "https://www.marriott.com/offers/spa-retreats-package-off-88552/tussp-jw-marriott-tucson-starr-pass-resort-and-spa?propertycode=tussp",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -22954,6 +24237,7 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -22991,6 +24275,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"4"
 				]
@@ -23018,6 +24303,11 @@
 			"categories": {
 				"set": [
 					"3"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -23048,6 +24338,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3",
 					"7"
@@ -23080,6 +24371,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"2"
 				]
@@ -23109,6 +24401,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"7",
 					"3"
@@ -23139,6 +24432,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -23216,6 +24510,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -23364,6 +24659,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3"
 				]
@@ -23388,6 +24684,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"3"
 				]
@@ -23452,6 +24749,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"3"
 				]
@@ -23476,6 +24774,11 @@
 				"set": [
 					"3",
 					"2"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -23525,6 +24828,11 @@
 			},
 			"title": "Members-Only Deal",
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -23543,6 +24851,11 @@
 			"categories": {
 				"set": [
 					"3"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -23572,6 +24885,11 @@
 					"4"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -23599,6 +24917,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"2",
 					"7"
@@ -23711,6 +25030,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"2",
 					"7"
@@ -23736,6 +25056,11 @@
 				"set": [
 					"2",
 					"3",
+					"1"
+				]
+			},
+			"channels": {
+				"set": [
 					"1"
 				]
 			},
@@ -23791,6 +25116,7 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"4"
 				]
@@ -23817,6 +25143,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"7",
 					"4"
@@ -23843,6 +25170,11 @@
 					"2",
 					"1",
 					"3"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -23873,6 +25205,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -23897,6 +25230,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"rank": {
 				"set": "2"
 			},
@@ -23912,6 +25250,7 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -23997,6 +25336,11 @@
 			"categories": {
 				"set": [
 					"4"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -24151,6 +25495,7 @@
 			"description": "thank you to First Responders and Veterans for their service. Stop by and enjoy 10% off food purchases. Wednesday through Saturday Cost:  Varies by food item. Wednesdays and Thursdays from 4-8 p.m. and Fridays and Saturdays from 4-9 p.m. Proof of service is required. Cannot be combined with other offers.",
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -24182,6 +25527,11 @@
 				"set": [
 					"4",
 					"3",
+					"1"
+				]
+			},
+			"channels": {
+				"set": [
 					"1"
 				]
 			},
@@ -24315,6 +25665,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3",
 					"7"
@@ -24397,6 +25748,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -24449,6 +25801,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -24493,6 +25846,7 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"2"
 				]
@@ -24579,6 +25933,11 @@
 			},
 			"title": "Festival Weekend Package",
 			"description": " Now is a great time to introduce your family and friends to the world of paintball. Offer includes entry to the  paintball fields, a paintball gun rental, goggles facemask rental, unlimited N2 air fills, free parking, professional paintball referees, as well as all day play. Available: June 14, August 18, September 29, October 13 an 14 Cost:  $21.50 person with pre-registration discount, $42.99 person on game day. Ages 10 and up. ",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -24601,6 +25960,7 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -24655,6 +26015,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"3"
 				]
@@ -24687,6 +26048,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3"
 				]
@@ -24723,6 +26085,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3"
 				]
@@ -24769,6 +26132,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -24792,6 +26156,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -24830,6 +26195,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -24904,6 +26270,7 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3"
 				]
@@ -24945,6 +26312,11 @@
 					"1"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -24966,6 +26338,11 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"weburl": "https://www.marriott.com/offers/spa-retreats-package-off-88552/tussp-jw-marriott-tucson-starr-pass-resort-and-spa?propertycode=tussp",
 			"categories": {
+				"set": [
+					"1"
+				]
+			},
+			"channels": {
 				"set": [
 					"1"
 				]
@@ -24996,6 +26373,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"2",
 					"3"
@@ -25018,6 +26396,11 @@
 			},
 			"title": "Limited Time Promotion",
 			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -25039,6 +26422,11 @@
 			"categories": {
 				"set": [
 					"2"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -25093,6 +26481,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"4"
 				]
@@ -25170,6 +26559,7 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3"
 				]
@@ -25231,6 +26621,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -25252,6 +26643,7 @@
 			"description": "thank you to First Responders and Veterans for their service. Stop by and enjoy 10% off food purchases. Wednesday through Saturday Cost:  Varies by food item. Wednesdays and Thursdays from 4-8 p.m. and Fridays and Saturdays from 4-9 p.m. Proof of service is required. Cannot be combined with other offers.",
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -25307,6 +26699,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"7",
 					"2"
@@ -25402,6 +26795,11 @@
 					"1"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -25423,6 +26821,7 @@
 			"description": "Enjoy non-stop gaming action and the relaxing four-season pool. This package includes a $100 dining credit to Lucky 8 Noodle and Sushi Bar! Available:  Seven days a week.Call or visit website for pricing.",
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"3"
 				]
@@ -25475,6 +26874,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3",
 					"2"
@@ -25588,6 +26988,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -25614,6 +27015,11 @@
 					"1"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -25632,6 +27038,11 @@
 				"set": "36"
 			},
 			"title": "Day Trip Special",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -25657,6 +27068,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3"
 				]
@@ -25678,6 +27090,11 @@
 					"3"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -25697,6 +27114,11 @@
 			"categories": {
 				"set": [
 					"3",
+					"1"
+				]
+			},
+			"channels": {
+				"set": [
 					"1"
 				]
 			},
@@ -25724,6 +27146,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3"
 				]
@@ -25758,6 +27181,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"7"
 				]
@@ -25810,6 +27234,7 @@
 			"description": " Enjoy half priced margaritas from open to close every Monday.",
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3",
 					"7"
@@ -25839,6 +27264,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"7",
 					"4"
@@ -25874,6 +27300,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"2",
 					"4"
@@ -25904,6 +27331,11 @@
 					"3"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -25926,6 +27358,7 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"7"
 				]
@@ -25958,6 +27391,11 @@
 			"categories": {
 				"set": [
 					"3"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"rank": {
@@ -25993,6 +27431,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -26017,6 +27456,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3"
 				]
@@ -26043,6 +27483,11 @@
 					"1"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -26063,6 +27508,11 @@
 				"set": [
 					"3",
 					"4",
+					"1"
+				]
+			},
+			"channels": {
+				"set": [
 					"1"
 				]
 			},
@@ -26117,6 +27567,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -26137,6 +27588,11 @@
 			},
 			"title": "Date Night at Lucky 8",
 			"description": " Now is a great time to introduce your family and friends to the world of paintball. Offer includes entry to the  paintball fields, a paintball gun rental, goggles facemask rental, unlimited N2 air fills, free parking, professional paintball referees, as well as all day play. Available: June 14, August 18, September 29, October 13 an 14 Cost:  $21.50 person with pre-registration discount, $42.99 person on game day. Ages 10 and up. ",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -26154,6 +27610,11 @@
 			},
 			"title": "Weekend Getaway Special",
 			"description": "thank you to First Responders and Veterans for their service. Stop by and enjoy 10% off food purchases. Wednesday through Saturday Cost:  Varies by food item. Wednesdays and Thursdays from 4-8 p.m. and Fridays and Saturdays from 4-9 p.m. Proof of service is required. Cannot be combined with other offers.",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -26175,6 +27636,11 @@
 			"categories": {
 				"set": [
 					"3",
+					"1"
+				]
+			},
+			"channels": {
+				"set": [
 					"1"
 				]
 			},
@@ -26219,6 +27685,11 @@
 			},
 			"title": "Early Bird Discount",
 			"description": "thank you to First Responders and Veterans for their service. Stop by and enjoy 10% off food purchases. Wednesday through Saturday Cost:  Varies by food item. Wednesdays and Thursdays from 4-8 p.m. and Fridays and Saturdays from 4-9 p.m. Proof of service is required. Cannot be combined with other offers.",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"1"
@@ -26248,6 +27719,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3"
 				]
@@ -26324,6 +27796,7 @@
 			"description": "This is my 4th Street Offer!\nCome and get it!",
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -26353,6 +27826,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"post_from_at": "2025-10-13T07:00:00.000Z",
 			"post_to_at": "2025-10-25T07:00:00.000Z",
 			"redeem_from_at": "2025-05-06T07:00:00.000Z",
@@ -26367,6 +27845,11 @@
 				"set": [
 					"2",
 					"4"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -26395,6 +27878,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"2",
 					"3"
@@ -26422,6 +27906,11 @@
 					"2"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -26442,6 +27931,11 @@
 			},
 			"title": "Family Fun Package",
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -26466,6 +27960,11 @@
 					"1",
 					"2",
 					"3"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -26496,6 +27995,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"4"
 				]
@@ -26552,6 +28052,11 @@
 			"title": "Kids Eat Free Promotion",
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"weburl": "https://www.marriott.com/offers/spa-retreats-package-off-88552/tussp-jw-marriott-tucson-starr-pass-resort-and-spa?propertycode=tussp",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -26569,6 +28074,7 @@
 			"description": "thank you to First Responders and Veterans for their service. Stop by and enjoy 10% off food purchases. Wednesday through Saturday Cost:  Varies by food item. Wednesdays and Thursdays from 4-8 p.m. and Fridays and Saturdays from 4-9 p.m. Proof of service is required. Cannot be combined with other offers.",
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -26626,6 +28132,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -26778,6 +28285,7 @@
 			"description": " Time to drop the books and hit the fields. All students are invited to play paintball for half price. That's right, all day paintball fun at half the price. Don't miss out on this limited time paintball offer!Every person that makes advance reservations and is paid in full at least 24 hours in advance will receive 100 free paintballs. 2026:  January 6, 7; February 3, 4, 24, 25; March 25, 26, 27, 28, 29, 30; April 1, 2, 3, 4, 5.Cost:$20.99 person with pre-registration discount. $41.99 person on game day. Ages 10 and up. Must have a valid student ID. Call to pre-register. ",
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"7"
 				]
@@ -26826,6 +28334,11 @@
 			"categories": {
 				"set": [
 					"2"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -26884,6 +28397,11 @@
 					"1"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"26"
@@ -26910,6 +28428,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3"
 				]
@@ -26934,6 +28453,11 @@
 			"title": "My 4th Street Full Offer",
 			"description": "This is my 4th Street Offer!\nCome and get it!",
 			"categories": {
+				"set": [
+					"1"
+				]
+			},
+			"channels": {
 				"set": [
 					"1"
 				]
@@ -26963,6 +28487,11 @@
 				"set": [
 					"3",
 					"2",
+					"1"
+				]
+			},
+			"channels": {
+				"set": [
 					"1"
 				]
 			},
@@ -27048,6 +28577,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"4"
 				]
@@ -27068,6 +28598,11 @@
 			},
 			"title": "Midweek Escape Special",
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"12"
@@ -27089,6 +28624,7 @@
 			"description": "thank you to First Responders and Veterans for their service. Stop by and enjoy 10% off food purchases. Wednesday through Saturday Cost:  Varies by food item. Wednesdays and Thursdays from 4-8 p.m. and Fridays and Saturdays from 4-9 p.m. Proof of service is required. Cannot be combined with other offers.",
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -27138,6 +28674,11 @@
 					"3"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"6"
@@ -27160,6 +28701,11 @@
 					"1",
 					"3",
 					"2"
+				]
+			},
+			"channels": {
+				"set": [
+					"1"
 				]
 			},
 			"listings": {
@@ -27191,6 +28737,11 @@
 					"4"
 				]
 			},
+			"channels": {
+				"set": [
+					"1"
+				]
+			},
 			"listings": {
 				"set": [
 					"33"
@@ -27215,6 +28766,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -27250,6 +28802,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4"
 				]
 			},
@@ -27277,6 +28830,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"4"
 				]
@@ -27306,6 +28860,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3"
 				]
 			},
@@ -27337,6 +28892,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"3",
 					"7",
 					"2"
@@ -27373,6 +28929,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"3",
 					"7"
@@ -27453,6 +29010,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"4",
 					"7",
 					"3"
@@ -27481,6 +29039,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -27506,6 +29065,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2"
 				]
 			},
@@ -27532,6 +29092,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7",
 					"2",
 					"4"
@@ -27564,6 +29125,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"2",
 					"3",
 					"4"
@@ -27596,6 +29158,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},
@@ -27621,6 +29184,7 @@
 			},
 			"channels": {
 				"set": [
+					"1",
 					"7"
 				]
 			},

--- a/data/offers_automated.json
+++ b/data/offers_automated.json
@@ -17,7 +17,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3"
 				]
@@ -51,7 +50,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -82,7 +80,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"4",
 					"2"
@@ -175,7 +172,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3"
 				]
@@ -284,7 +280,6 @@
 			"description": "Enjoy non-stop gaming action and the relaxing four-season pool. This package includes a $100 dining credit to Lucky 8 Noodle and Sushi Bar! Available:  Seven days a week.Call or visit website for pricing.",
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -312,7 +307,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"4",
 					"3"
@@ -494,7 +488,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -537,7 +530,6 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"2",
 					"3"
@@ -564,7 +556,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"2",
 					"3"
@@ -648,7 +639,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -683,7 +673,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"4"
 				]
@@ -741,7 +730,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -830,7 +818,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -854,7 +841,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -877,7 +863,6 @@
 			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp",
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7",
 					"4"
@@ -903,7 +888,6 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"3"
 				]
@@ -971,7 +955,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -1082,7 +1065,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7"
 				]
@@ -1168,7 +1150,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"2",
 					"4"
@@ -1224,7 +1205,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3"
 				]
@@ -1357,7 +1337,6 @@
 			"title": "Date Night at Lucky 8",
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -1394,7 +1373,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"2",
 					"4"
@@ -1514,7 +1492,6 @@
 			"title": "Birthday Bonus Package",
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"2"
 				]
@@ -1548,7 +1525,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7"
 				]
@@ -1645,7 +1621,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -1810,7 +1785,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -1891,7 +1865,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"3",
 					"4"
@@ -2022,7 +1995,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3"
 				]
@@ -2081,7 +2053,6 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -2173,7 +2144,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"4"
 				]
@@ -2202,7 +2172,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -2232,7 +2201,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"4"
 				]
@@ -2360,7 +2328,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"7"
 				]
@@ -2430,7 +2397,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"7"
 				]
@@ -2457,7 +2423,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -2487,7 +2452,6 @@
 			"title": "Golf and Stay Package",
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"4"
 				]
@@ -2520,7 +2484,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3",
 					"7"
@@ -2578,7 +2541,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"2"
 				]
@@ -2702,7 +2664,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -2735,7 +2696,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3",
 					"2"
@@ -2819,7 +2779,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"7"
 				]
@@ -2851,7 +2810,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -2878,7 +2836,6 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -2935,7 +2892,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -3004,7 +2960,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -3050,7 +3005,6 @@
 			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp",
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"4"
 				]
@@ -3076,7 +3030,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"7"
 				]
@@ -3107,7 +3060,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -3136,7 +3088,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"4"
 				]
@@ -3321,7 +3272,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3"
 				]
@@ -3458,7 +3408,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"7",
 					"2"
@@ -3637,7 +3586,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -3870,7 +3818,6 @@
 			"title": "Buy One Get One Half Off",
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -3892,7 +3839,6 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"7"
 				]
@@ -3913,7 +3859,6 @@
 			"description": "Enjoy non-stop gaming action and the relaxing four-season pool. This package includes a $100 dining credit to Lucky 8 Noodle and Sushi Bar! Available:  Seven days a week.Call or visit website for pricing.",
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -4004,7 +3949,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"4"
 				]
@@ -4055,7 +3999,6 @@
 			"weburl": "https://www.marriott.com/offers/spa-retreats-package-off-88552/tussp-jw-marriott-tucson-starr-pass-resort-and-spa?propertycode=tussp",
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"7"
 				]
@@ -4081,7 +4024,6 @@
 			"description": "This is my 4th Street Offer!\nCome and get it!",
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -4132,7 +4074,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"7"
 				]
@@ -4186,7 +4127,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -4236,7 +4176,6 @@
 			"description": " Time to drop the books and hit the fields. All students are invited to play paintball for half price. That's right, all day paintball fun at half the price. Don't miss out on this limited time paintball offer!Every person that makes advance reservations and is paid in full at least 24 hours in advance will receive 100 free paintballs. 2026:  January 6, 7; February 3, 4, 24, 25; March 25, 26, 27, 28, 29, 30; April 1, 2, 3, 4, 5.Cost:$20.99 person with pre-registration discount. $41.99 person on game day. Ages 10 and up. Must have a valid student ID. Call to pre-register. ",
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"2"
 				]
@@ -4317,7 +4256,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"4",
 					"2"
@@ -4520,7 +4458,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"4",
 					"2"
@@ -4577,7 +4514,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"4"
 				]
@@ -4605,7 +4541,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"2",
 					"3"
@@ -4709,7 +4644,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3",
 					"7"
@@ -4739,7 +4673,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -4786,7 +4719,6 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3"
 				]
@@ -4816,7 +4748,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"2",
 					"4"
@@ -4845,7 +4776,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"4",
 					"3"
@@ -4877,7 +4807,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -4938,7 +4867,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"3",
 					"4"
@@ -5002,7 +4930,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"2",
 					"4"
@@ -5025,7 +4952,6 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -5074,7 +5000,6 @@
 			"description": "Enjoy non-stop gaming action and the relaxing four-season pool. This package includes a $100 dining credit to Lucky 8 Noodle and Sushi Bar! Available:  Seven days a week.Call or visit website for pricing.",
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -5096,7 +5021,6 @@
 			"description": "Get in the holiday spirit and enjoy Winterfest.  Stay in one of the spacious and charming queen rooms for two nights. Winterfest can be your one stop to get into the festive spirit. Listen to Christmas carols, visit the beautifully-decorated historic homes, shop in town, and take in the spirit of Christmas!  Rates start at $109 night, based on double occupancy, two-night minimum; includes tax.",
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"3",
 					"2"
@@ -5157,7 +5081,6 @@
 			"description": "Sseasonal equipment rentals are perfect for those not ready to invest in their own equipment, or families with young and fast-growing children. Grab your gear once and it's yours to keep for the whole season! No more waiting in rental line, just more time in the great outdoors. $279 includes skis snowboard, boots, bindings, and poles.",
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -5189,7 +5112,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"2",
 					"7"
@@ -5227,7 +5149,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -5256,7 +5177,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -5314,7 +5234,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"4"
 				]
@@ -5363,7 +5282,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"4"
 				]
@@ -5391,7 +5309,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"4"
 				]
@@ -5456,7 +5373,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"7"
 				]
@@ -5570,7 +5486,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"3",
 					"2"
@@ -5604,7 +5519,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"7",
 					"3"
@@ -5629,7 +5543,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"4",
 					"2"
@@ -5652,7 +5565,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3"
 				]
@@ -5771,7 +5683,6 @@
 			"weburl": "https://www.marriott.com/offers/spa-retreats-package-off-88552/tussp-jw-marriott-tucson-starr-pass-resort-and-spa?propertycode=tussp",
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7"
 				]
@@ -5889,7 +5800,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"7"
 				]
@@ -5939,7 +5849,6 @@
 			"weburl": "https://www.marriott.com/offers/spa-retreats-package-off-88552/tussp-jw-marriott-tucson-starr-pass-resort-and-spa?propertycode=tussp",
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"2",
 					"4"
@@ -5972,7 +5881,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -6059,7 +5967,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"2"
 				]
@@ -6155,7 +6062,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3"
 				]
@@ -6239,7 +6145,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"7",
 					"2"
@@ -6269,7 +6174,6 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -6297,7 +6201,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"2"
 				]
@@ -6352,7 +6255,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -6498,7 +6400,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"2"
 				]
@@ -6627,7 +6528,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"3"
 				]
@@ -6657,7 +6557,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"2",
 					"3"
@@ -6756,7 +6655,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -7214,7 +7112,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -7243,7 +7140,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3",
 					"2"
@@ -7337,7 +7233,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -7365,7 +7260,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7",
 					"4"
@@ -7419,7 +7313,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7"
 				]
@@ -7458,7 +7351,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -7524,7 +7416,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"7",
 					"2"
@@ -7591,7 +7482,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -7649,7 +7539,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -7711,7 +7600,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3"
 				]
@@ -7766,7 +7654,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"3",
 					"2"
@@ -7799,7 +7686,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"2",
 					"7"
@@ -7821,7 +7707,6 @@
 			"title": "Grand Opening Special",
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3",
 					"7"
@@ -7854,7 +7739,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"3"
 				]
@@ -7892,7 +7776,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7",
 					"4"
@@ -7919,7 +7802,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"3",
 					"4"
@@ -8031,7 +7913,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -8189,7 +8070,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"4"
 				]
@@ -8322,7 +8202,6 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3"
 				]
@@ -8424,7 +8303,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"2",
 					"4"
@@ -8598,7 +8476,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"2"
 				]
@@ -8648,7 +8525,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"2"
 				]
@@ -8734,7 +8610,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"2",
 					"4"
@@ -8768,7 +8643,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7",
 					"4"
@@ -8798,7 +8672,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -8823,7 +8696,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"4"
 				]
@@ -8886,7 +8758,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -9004,7 +8875,6 @@
 			"description": " Celebrate your love any day of the week when you book a romance special! A beautiful floral arrangement from Gorgeous Floral, chocolate from Moka Origins, and a bottle of bubbly will be in your room upon arrival! Enjoy some time reconnecting by the fire, or take a stroll through the woods before enjoying a sumptuous dinner. Awake refreshed and enjoy a delicious breakfast. February is the perfect month for an escape! Available: Seven days a week Price varies depending upon your choice of accommodation. Please call to book this getaway. Pricing is based on double occupancy. No other discounts can be applied. ",
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3"
 				]
@@ -9088,7 +8958,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -9115,7 +8984,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"4"
 				]
@@ -9177,7 +9045,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -9256,7 +9123,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"2"
 				]
@@ -9287,7 +9153,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3"
 				]
@@ -9379,7 +9244,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"7"
 				]
@@ -9408,7 +9272,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -9440,7 +9303,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"2",
 					"3"
@@ -9496,7 +9358,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"4"
 				]
@@ -9645,7 +9506,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7"
 				]
@@ -9676,7 +9536,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -9745,7 +9604,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -9799,7 +9657,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"4",
 					"2"
@@ -9884,7 +9741,6 @@
 			"description": " Now is a great time to introduce your family and friends to the world of paintball. Offer includes entry to the  paintball fields, a paintball gun rental, goggles facemask rental, unlimited N2 air fills, free parking, professional paintball referees, as well as all day play. Available: June 14, August 18, September 29, October 13 an 14 Cost:  $21.50 person with pre-registration discount, $42.99 person on game day. Ages 10 and up. ",
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"2"
 				]
@@ -9913,7 +9769,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -10021,7 +9876,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"2"
 				]
@@ -10053,7 +9907,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -10078,7 +9931,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"2"
 				]
@@ -10104,7 +9956,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -10121,7 +9972,6 @@
 			"description": "Get the best deal on the Summer Adventure Overnight Camp! Stay the week and explore the mountain day and night. Overnight campers experience the same adventures of the day campers, but have the added fun of spending their mornings and nights! Experience after dark with night hiking, stargazing and sitting around the campfire telling stories and roasting smores! ",
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"7"
 				]
@@ -10153,7 +10003,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -10185,7 +10034,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"4"
 				]
@@ -10217,7 +10065,6 @@
 			"description": " Give yourself a chance to experience romance. Enjoy a romantic atmosphere as we take it the next level with the perfect package to share with your loved one. Offer includes three days and two nights, romantic decoration in the room, one bottle of wine, desserts, appetizer and one breakfast per couple (chef's selection.) Available:  Seven days a week Call for pricing. Restrictions may apply. Subject to availability ",
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7",
 					"4"
@@ -10252,7 +10099,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -10337,7 +10183,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"2",
 					"4"
@@ -10365,7 +10210,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"2"
 				]
@@ -10397,7 +10241,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -10424,7 +10267,6 @@
 			"description": "Enjoy non-stop gaming action and the relaxing four-season pool. This package includes a $100 dining credit to Lucky 8 Noodle and Sushi Bar! Available:  Seven days a week.Call or visit website for pricing.",
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -10477,7 +10319,6 @@
 			"description": " Life is a journey. Strength is one quality it takes to skillfully move through this adventure, doing everything you need to experience a deep sense of fulfillment and cultivate everlasting freedom. This weekend combines the brilliance of yoga its strengthening, lengthening, opening, expanding, and relaxing consequences with the magic of a retreat format that will restore, revitalize, and help you reconnect. Immerse yourself into the study and practice sessions with Luke this weekend, and explore how to create a sustainable environment on all levels through a practice designed to meet you where you are. Your strong and resilient self awaits! Look forward to seeing you at this special retreat. vailable:  Friday through Sunday Visit website for call for pricing.",
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -10505,7 +10346,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -10616,7 +10456,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"3",
 					"2"
@@ -10653,7 +10492,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -10712,7 +10550,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -10739,7 +10576,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -10770,7 +10606,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"4"
 				]
@@ -10800,7 +10635,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -10922,7 +10756,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -10980,7 +10813,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7",
 					"3"
@@ -11011,7 +10843,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"3"
 				]
@@ -11038,7 +10869,6 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"4",
 					"3"
@@ -11099,7 +10929,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -11376,7 +11205,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -11406,7 +11234,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -11502,7 +11329,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -11533,7 +11359,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3"
 				]
@@ -11590,7 +11415,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"3"
 				]
@@ -11651,7 +11475,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -11710,7 +11533,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -11776,7 +11598,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -11795,7 +11616,6 @@
 			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp",
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -11989,7 +11809,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -12020,7 +11839,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7"
 				]
@@ -12047,7 +11865,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -12109,7 +11926,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -12132,7 +11948,6 @@
 			"description": "Enjoy non-stop gaming action and the relaxing four-season pool. This package includes a $100 dining credit to Lucky 8 Noodle and Sushi Bar! Available:  Seven days a week.Call or visit website for pricing.",
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"2"
 				]
@@ -12194,7 +12009,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -12378,7 +12192,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -12405,7 +12218,6 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -12435,7 +12247,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -12461,7 +12272,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -12500,7 +12310,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3",
 					"2"
@@ -12557,7 +12366,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -12588,7 +12396,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7"
 				]
@@ -12614,7 +12421,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"4",
 					"3"
@@ -12676,7 +12482,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -12802,7 +12607,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -12836,7 +12640,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3",
 					"4"
@@ -12894,7 +12697,6 @@
 			"description": "Get in the holiday spirit and enjoy Winterfest.  Stay in one of the spacious and charming queen rooms for two nights. Winterfest can be your one stop to get into the festive spirit. Listen to Christmas carols, visit the beautifully-decorated historic homes, shop in town, and take in the spirit of Christmas!  Rates start at $109 night, based on double occupancy, two-night minimum; includes tax.",
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -12921,7 +12723,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"7",
 					"2"
@@ -12949,7 +12750,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"3",
 					"2"
@@ -13000,7 +12800,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -13060,7 +12859,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3",
 					"4"
@@ -13124,7 +12922,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -13146,7 +12943,6 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -13179,7 +12975,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -13206,7 +13001,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -13264,7 +13058,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"4"
 				]
@@ -13286,7 +13079,6 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -13314,7 +13106,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"2",
 					"3"
@@ -13339,7 +13130,6 @@
 			"description": "Its time to relax, refresh and rejuvenate! From hiking, biking and the unforgettable treetop adventure course to nightly campfires and marshmallow roasts, save on the freshest moments of the season. So, whether serenity or high octane adventure is on the agenda, the ideal place for an unforgettable springtime escape. The Spring Renewal Bed and Breakfast offer includes delicious daily breakfast, AAA 4-Diamond accommodations with up to 10% off room rates, $100 in resort credits (stay two nights get $60 in resort credits, stay three nights get $100 in resort credits.) See website for details. Terms and conditions apply. Based on availability. Must cancel seven days prior to arrival to receive full refund. No credit or refund will be issued for any unused portions of this package. Travel window: 02 26-05 23 2026. All activities are weather dependent and may require reservations and or a fee.",
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3"
 				]
@@ -13529,7 +13319,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7"
 				]
@@ -13561,7 +13350,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"7"
 				]
@@ -13598,7 +13386,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -13649,7 +13436,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -13697,7 +13483,6 @@
 			"description": "This is my 4th Street Offer!\nCome and get it!",
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -13731,7 +13516,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -13845,7 +13629,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3"
 				]
@@ -13874,7 +13657,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"2",
 					"7"
@@ -13933,7 +13715,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -14047,7 +13828,6 @@
 			"weburl": "https://www.marriott.com/offers/spa-retreats-package-off-88552/tussp-jw-marriott-tucson-starr-pass-resort-and-spa?propertycode=tussp",
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3",
 					"7"
@@ -14088,7 +13868,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"4",
 					"3"
@@ -14112,7 +13891,6 @@
 			"description": " Now is a great time to introduce your family and friends to the world of paintball. Offer includes entry to the  paintball fields, a paintball gun rental, goggles facemask rental, unlimited N2 air fills, free parking, professional paintball referees, as well as all day play. Available: June 14, August 18, September 29, October 13 an 14 Cost:  $21.50 person with pre-registration discount, $42.99 person on game day. Ages 10 and up. ",
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"2",
 					"7"
@@ -14143,7 +13921,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7"
 				]
@@ -14162,7 +13939,6 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7",
 					"3"
@@ -14187,7 +13963,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3",
 					"7"
@@ -14276,7 +14051,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"4"
 				]
@@ -14332,7 +14106,6 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7"
 				]
@@ -14433,7 +14206,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -14494,7 +14266,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -14679,7 +14450,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"7"
 				]
@@ -14711,7 +14481,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -14923,7 +14692,6 @@
 			"description": "Enjoy non-stop gaming action and the relaxing four-season pool. This package includes a $100 dining credit to Lucky 8 Noodle and Sushi Bar! Available:  Seven days a week.Call or visit website for pricing.",
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -14955,7 +14723,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"4"
 				]
@@ -14991,7 +14758,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -15018,7 +14784,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -15109,7 +14874,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -15185,7 +14949,6 @@
 			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp",
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"7"
 				]
@@ -15319,7 +15082,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3",
 					"7"
@@ -15379,7 +15141,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"7"
 				]
@@ -15406,7 +15167,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3"
 				]
@@ -15440,7 +15200,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"2"
 				]
@@ -15469,7 +15228,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"4",
 					"2"
@@ -15498,7 +15256,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -15587,7 +15344,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"2",
 					"3"
@@ -15644,7 +15400,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -15765,7 +15520,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -15821,7 +15575,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"4"
 				]
@@ -15912,7 +15665,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -15945,7 +15697,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -16068,7 +15819,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -16097,7 +15847,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"7",
 					"4"
@@ -16147,7 +15896,6 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"4"
 				]
@@ -16172,7 +15920,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"4"
 				]
@@ -16238,7 +15985,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7"
 				]
@@ -16268,7 +16014,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"4"
 				]
@@ -16356,7 +16101,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"2"
 				]
@@ -16384,7 +16128,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -16419,7 +16162,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -16455,7 +16197,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"7",
 					"3"
@@ -16566,7 +16307,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"4"
 				]
@@ -16601,7 +16341,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"7",
 					"4"
@@ -16631,7 +16370,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -16767,7 +16505,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"7",
 					"2"
@@ -16837,7 +16574,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -16865,7 +16601,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -16894,7 +16629,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -16929,7 +16663,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"3"
 				]
@@ -17013,7 +16746,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -17064,7 +16796,6 @@
 			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp",
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -17089,7 +16820,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -17118,7 +16848,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -17178,7 +16907,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -17208,7 +16936,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"4",
 					"7"
@@ -17233,7 +16960,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -17258,7 +16984,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -17291,7 +17016,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -17415,7 +17139,6 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"3"
 				]
@@ -17478,7 +17201,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7"
 				]
@@ -17507,7 +17229,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3"
 				]
@@ -17538,7 +17259,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -17625,7 +17345,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -17651,7 +17370,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7"
 				]
@@ -17760,7 +17478,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3"
 				]
@@ -17787,7 +17504,6 @@
 			"weburl": "https://www.marriott.com/offers/spa-retreats-package-off-88552/tussp-jw-marriott-tucson-starr-pass-resort-and-spa?propertycode=tussp",
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"7"
 				]
@@ -17820,7 +17536,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -17853,7 +17568,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -17918,7 +17632,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"3"
 				]
@@ -17972,7 +17685,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"2"
 				]
@@ -18005,7 +17717,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"2"
 				]
@@ -18102,7 +17813,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -18128,7 +17838,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7"
 				]
@@ -18162,7 +17871,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"2",
 					"4"
@@ -18251,7 +17959,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"4",
 					"2"
@@ -18311,7 +18018,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -18368,7 +18074,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -18397,7 +18102,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -18454,7 +18158,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -18488,7 +18191,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3",
 					"7"
@@ -18521,7 +18223,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -18602,7 +18303,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"7",
 					"4"
@@ -18692,7 +18392,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"2"
 				]
@@ -18721,7 +18420,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7",
 					"3"
@@ -18833,7 +18531,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"7"
 				]
@@ -18862,7 +18559,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -18882,7 +18578,6 @@
 			"description": " Now is a great time to introduce your family and friends to the world of paintball. Offer includes entry to the  paintball fields, a paintball gun rental, goggles facemask rental, unlimited N2 air fills, free parking, professional paintball referees, as well as all day play. Available: June 14, August 18, September 29, October 13 an 14 Cost:  $21.50 person with pre-registration discount, $42.99 person on game day. Ages 10 and up. ",
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -18906,7 +18601,6 @@
 			"description": "Spring into Summer with rates staring at $279, there is no reason to wait to book your Summer getaway! Reserve  Spring into Summer offer by March 31, 2026 and receive a resort credit to enhance your stay. The offer includes AAA four-diamond accommodations, daily breakfast, up to $250 daily resort credits (stay two nights and received $80, stay three nights and receive $150, stay four nights and receive $250.)Call (855) 345-7759 for available rates or see website for details. Book by March 31, 2026.",
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"2"
 				]
@@ -19116,7 +18810,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3"
 				]
@@ -19178,7 +18871,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -19209,7 +18901,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -19299,7 +18990,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -19352,7 +19042,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"2"
 				]
@@ -19429,7 +19118,6 @@
 			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp",
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"2",
 					"4"
@@ -19488,7 +19176,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -19562,7 +19249,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"7"
 				]
@@ -19588,7 +19274,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -19625,7 +19310,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"2",
 					"4"
@@ -19650,7 +19334,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -19735,7 +19418,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -19767,7 +19449,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7",
 					"3"
@@ -19828,7 +19509,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -19869,7 +19549,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -19916,7 +19595,6 @@
 			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp",
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -19974,7 +19652,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -20066,7 +19743,6 @@
 			"title": "Limited Time Promotion",
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -20092,7 +19768,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"2",
 					"3"
@@ -20152,7 +19827,6 @@
 			"title": "Spring Getaway Special - 15% Off",
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"2",
 					"7"
@@ -20186,7 +19860,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -20216,7 +19889,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3",
 					"4"
@@ -20337,7 +20009,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -20368,7 +20039,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3",
 					"7"
@@ -20402,7 +20072,6 @@
 			"description": "This is my 4th Street Offer!\nCome and get it!",
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"4"
 				]
@@ -20440,7 +20109,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3"
 				]
@@ -20469,7 +20137,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -20544,7 +20211,6 @@
 			"description": "This is my 4th Street Offer!\nCome and get it!",
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -20668,7 +20334,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -20697,7 +20362,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"4"
 				]
@@ -20726,7 +20390,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -20783,7 +20446,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3"
 				]
@@ -20815,7 +20477,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"7"
 				]
@@ -20868,7 +20529,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -20888,7 +20548,6 @@
 			"weburl": "https://www.marriott.com/offers/long-term-stay-savings-in-the-u-s-and-canada-1355935?propertycode=tussp",
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -20923,7 +20582,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"7",
 					"2"
@@ -21008,7 +20666,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3",
 					"2"
@@ -21089,7 +20746,6 @@
 			"description": "Enjoy non-stop gaming action and the relaxing four-season pool. This package includes a $100 dining credit to Lucky 8 Noodle and Sushi Bar! Available:  Seven days a week.Call or visit website for pricing.",
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3"
 				]
@@ -21210,7 +20866,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"4",
 					"7"
@@ -21249,7 +20904,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -21310,7 +20964,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"4"
 				]
@@ -21333,7 +20986,6 @@
 			"description": " Time to drop the books and hit the fields. All students are invited to play paintball for half price. That's right, all day paintball fun at half the price. Don't miss out on this limited time paintball offer!Every person that makes advance reservations and is paid in full at least 24 hours in advance will receive 100 free paintballs. 2026:  January 6, 7; February 3, 4, 24, 25; March 25, 26, 27, 28, 29, 30; April 1, 2, 3, 4, 5.Cost:$20.99 person with pre-registration discount. $41.99 person on game day. Ages 10 and up. Must have a valid student ID. Call to pre-register. ",
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"4",
 					"7"
@@ -21513,7 +21165,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"4"
 				]
@@ -21546,7 +21197,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -21629,7 +21279,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"2",
 					"7"
@@ -21658,7 +21307,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -21687,7 +21335,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"3",
 					"2"
@@ -21744,7 +21391,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7",
 					"4"
@@ -21829,7 +21475,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"4",
 					"7"
@@ -21865,7 +21510,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -21894,7 +21538,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"2"
 				]
@@ -21952,7 +21595,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -22056,7 +21698,6 @@
 			"title": "Extended Stay Discount",
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -22084,7 +21725,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"7",
 					"4"
@@ -22116,7 +21756,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -22183,7 +21822,6 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -22296,7 +21934,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3",
 					"2"
@@ -22347,7 +21984,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7"
 				]
@@ -22438,7 +22074,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -22471,7 +22106,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3"
 				]
@@ -22496,7 +22130,6 @@
 			"title": "Kids Eat Free Promotion",
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"4",
 					"7"
@@ -22562,7 +22195,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -22621,7 +22253,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -22710,7 +22341,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -22741,7 +22371,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3",
 					"2"
@@ -22770,7 +22399,6 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3"
 				]
@@ -22826,7 +22454,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"7",
 					"3"
@@ -22857,7 +22484,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3"
 				]
@@ -22913,7 +22539,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3"
 				]
@@ -23026,7 +22651,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"7"
 				]
@@ -23146,7 +22770,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"2"
 				]
@@ -23261,7 +22884,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -23292,7 +22914,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -23330,7 +22951,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -23395,7 +23015,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"2"
 				]
@@ -23445,7 +23064,6 @@
 			"description": "thank you to First Responders and Veterans for their service. Stop by and enjoy 10% off food purchases. Wednesday through Saturday Cost:  Varies by food item. Wednesdays and Thursdays from 4-8 p.m. and Fridays and Saturdays from 4-9 p.m. Proof of service is required. Cannot be combined with other offers.",
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -23465,7 +23083,6 @@
 			"description": "Enjoy non-stop gaming action and the relaxing four-season pool. This package includes a $100 dining credit to Lucky 8 Noodle and Sushi Bar! Available:  Seven days a week.Call or visit website for pricing.",
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"2"
 				]
@@ -23614,7 +23231,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -23714,7 +23330,6 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"4"
 				]
@@ -23799,7 +23414,6 @@
 			"description": "Restaurant Week Includes:  Stop by and spend $35 or more and receive $7 off. Available: Sunday through Friday Cost:Spend $35 or more.",
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -23923,7 +23537,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"4"
 				]
@@ -23950,7 +23563,6 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -23976,7 +23588,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3",
 					"7"
@@ -24006,7 +23617,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"7",
 					"2"
@@ -24040,7 +23650,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"2"
 				]
@@ -24101,7 +23710,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3"
 				]
@@ -24122,7 +23730,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"7",
 					"2"
@@ -24237,7 +23844,6 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -24275,7 +23881,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"4"
 				]
@@ -24338,7 +23943,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3",
 					"7"
@@ -24371,7 +23975,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"2"
 				]
@@ -24401,7 +24004,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"7",
 					"3"
@@ -24432,7 +24034,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -24510,7 +24111,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -24659,7 +24259,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3"
 				]
@@ -24684,7 +24283,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"3"
 				]
@@ -24749,7 +24347,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"3"
 				]
@@ -24917,7 +24514,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"2",
 					"7"
@@ -25030,7 +24626,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"2",
 					"7"
@@ -25116,7 +24711,6 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"4"
 				]
@@ -25143,7 +24737,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"7",
 					"4"
@@ -25205,7 +24798,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -25250,7 +24842,6 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -25495,7 +25086,6 @@
 			"description": "thank you to First Responders and Veterans for their service. Stop by and enjoy 10% off food purchases. Wednesday through Saturday Cost:  Varies by food item. Wednesdays and Thursdays from 4-8 p.m. and Fridays and Saturdays from 4-9 p.m. Proof of service is required. Cannot be combined with other offers.",
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -25665,7 +25255,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3",
 					"7"
@@ -25748,7 +25337,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -25801,7 +25389,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -25846,7 +25433,6 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"2"
 				]
@@ -25960,7 +25546,6 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -26015,7 +25600,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"3"
 				]
@@ -26048,7 +25632,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3"
 				]
@@ -26085,7 +25668,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3"
 				]
@@ -26132,7 +25714,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -26156,7 +25737,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -26195,7 +25775,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -26270,7 +25849,6 @@
 			"weburl": "http://www.4thstreetmarket.com",
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3"
 				]
@@ -26373,7 +25951,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"2",
 					"3"
@@ -26481,7 +26058,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"4"
 				]
@@ -26559,7 +26135,6 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3"
 				]
@@ -26621,7 +26196,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -26643,7 +26217,6 @@
 			"description": "thank you to First Responders and Veterans for their service. Stop by and enjoy 10% off food purchases. Wednesday through Saturday Cost:  Varies by food item. Wednesdays and Thursdays from 4-8 p.m. and Fridays and Saturdays from 4-9 p.m. Proof of service is required. Cannot be combined with other offers.",
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -26699,7 +26272,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"7",
 					"2"
@@ -26821,7 +26393,6 @@
 			"description": "Enjoy non-stop gaming action and the relaxing four-season pool. This package includes a $100 dining credit to Lucky 8 Noodle and Sushi Bar! Available:  Seven days a week.Call or visit website for pricing.",
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"3"
 				]
@@ -26874,7 +26445,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3",
 					"2"
@@ -26988,7 +26558,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -27068,7 +26637,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3"
 				]
@@ -27146,7 +26714,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3"
 				]
@@ -27181,7 +26748,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"7"
 				]
@@ -27234,7 +26800,6 @@
 			"description": " Enjoy half priced margaritas from open to close every Monday.",
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3",
 					"7"
@@ -27264,7 +26829,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"7",
 					"4"
@@ -27300,7 +26864,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"2",
 					"4"
@@ -27358,7 +26921,6 @@
 			"description": "Escape with your loved one with 5,500 acres of natural scenic beauty and relaxation. Enjoy a Couples Getaway Package designed to create unforgettable moments in a luxurious setting. Offer includes up to 15% discount on AAA four diamond accommodations, breakfast daily, complimentary bike rentals for two (value $30), in-room amenities to include fresh flowers, bottle of house Champagne and fresh baked shortbread cookies. ",
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"7"
 				]
@@ -27431,7 +26993,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -27456,7 +27017,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3"
 				]
@@ -27567,7 +27127,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -27719,7 +27278,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3"
 				]
@@ -27796,7 +27354,6 @@
 			"description": "This is my 4th Street Offer!\nCome and get it!",
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -27878,7 +27435,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"2",
 					"3"
@@ -27995,7 +27551,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"4"
 				]
@@ -28074,7 +27629,6 @@
 			"description": "thank you to First Responders and Veterans for their service. Stop by and enjoy 10% off food purchases. Wednesday through Saturday Cost:  Varies by food item. Wednesdays and Thursdays from 4-8 p.m. and Fridays and Saturdays from 4-9 p.m. Proof of service is required. Cannot be combined with other offers.",
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -28132,7 +27686,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -28285,7 +27838,6 @@
 			"description": " Time to drop the books and hit the fields. All students are invited to play paintball for half price. That's right, all day paintball fun at half the price. Don't miss out on this limited time paintball offer!Every person that makes advance reservations and is paid in full at least 24 hours in advance will receive 100 free paintballs. 2026:  January 6, 7; February 3, 4, 24, 25; March 25, 26, 27, 28, 29, 30; April 1, 2, 3, 4, 5.Cost:$20.99 person with pre-registration discount. $41.99 person on game day. Ages 10 and up. Must have a valid student ID. Call to pre-register. ",
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"7"
 				]
@@ -28428,7 +27980,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3"
 				]
@@ -28577,7 +28128,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"4"
 				]
@@ -28624,7 +28174,6 @@
 			"description": "thank you to First Responders and Veterans for their service. Stop by and enjoy 10% off food purchases. Wednesday through Saturday Cost:  Varies by food item. Wednesdays and Thursdays from 4-8 p.m. and Fridays and Saturdays from 4-9 p.m. Proof of service is required. Cannot be combined with other offers.",
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -28766,7 +28315,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -28802,7 +28350,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4"
 				]
 			},
@@ -28830,7 +28377,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"4"
 				]
@@ -28860,7 +28406,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3"
 				]
 			},
@@ -28892,7 +28437,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"3",
 					"7",
 					"2"
@@ -28929,7 +28473,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"3",
 					"7"
@@ -29010,7 +28553,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"4",
 					"7",
 					"3"
@@ -29039,7 +28581,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -29065,7 +28606,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2"
 				]
 			},
@@ -29092,7 +28632,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7",
 					"2",
 					"4"
@@ -29125,7 +28664,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"2",
 					"3",
 					"4"
@@ -29158,7 +28696,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},
@@ -29184,7 +28721,6 @@
 			},
 			"channels": {
 				"set": [
-					"1",
 					"7"
 				]
 			},

--- a/scripts/generateEvents.ts
+++ b/scripts/generateEvents.ts
@@ -3,8 +3,8 @@ import RandomUtils from "../src/RandomUtils";
 
 const EVENT_COUNT = 500;
 
-// date_rule_sets dates must be stored at client-timezone midnight (America/Phoenix, UTC-7),
-// so build them in UTC rather than the host timezone.
+// date_rule_sets dates must remain at client-timezone midnight (America/Phoenix, UTC-7),
+// independent of the host timezone.
 const CLIENT_UTC_OFFSET_HOURS = 7;
 
 const accounts = [

--- a/scripts/generateEvents.ts
+++ b/scripts/generateEvents.ts
@@ -3,6 +3,10 @@ import RandomUtils from "../src/RandomUtils";
 
 const EVENT_COUNT = 500;
 
+// date_rule_sets dates must be stored at client-timezone midnight (America/Phoenix, UTC-7),
+// so build them in UTC rather than the host timezone.
+const CLIENT_UTC_OFFSET_HOURS = 7;
+
 const accounts = [
 	"7",
 	"28",
@@ -65,6 +69,7 @@ const eventTitles = [
 
 interface Event {
 	account_id: string
+	channels: { set: string[] }
 	title: string
 	description: string
 	date_rule_sets: {
@@ -91,7 +96,7 @@ for (let i = 0; i < EVENT_COUNT; i++) {
 	const day = r.getRandomIntInclusive(0, 28);
 
 	const ruleSet = {
-		start_date_at: new Date(year, month, day).toISOString(),
+		start_date_at: new Date(Date.UTC(year, month, day, CLIENT_UTC_OFFSET_HOURS)).toISOString(),
 		start_time: "16:00",
 		end_time: "20:00",
 		frequency_id: "single_date"
@@ -99,6 +104,7 @@ for (let i = 0; i < EVENT_COUNT; i++) {
 
 	events.push({
 		account_id,
+		channels: { set: ["1"] },
 		title: r.randEntry(eventTitles),
 		description: "Enjoy the event open to all ages! Food vendors and family-friendly activities will be available throughout the day/night. Just come and enjoy the fun!",
 		date_rule_sets: {

--- a/scripts/generateEvents.ts
+++ b/scripts/generateEvents.ts
@@ -3,10 +3,6 @@ import RandomUtils from "../src/RandomUtils";
 
 const EVENT_COUNT = 500;
 
-// date_rule_sets dates must remain at client-timezone midnight (America/Phoenix, UTC-7),
-// independent of the host timezone.
-const CLIENT_UTC_OFFSET_HOURS = 7;
-
 const accounts = [
 	"7",
 	"28",
@@ -96,7 +92,7 @@ for (let i = 0; i < EVENT_COUNT; i++) {
 	const day = r.getRandomIntInclusive(0, 28);
 
 	const ruleSet = {
-		start_date_at: new Date(Date.UTC(year, month, day, CLIENT_UTC_OFFSET_HOURS)).toISOString(),
+		start_date_at: new Date(Date.UTC(year, month, day, 7, 0, 0)).toISOString(),
 		start_time: "16:00",
 		end_time: "20:00",
 		frequency_id: "single_date"

--- a/scripts/generateOffers.ts
+++ b/scripts/generateOffers.ts
@@ -120,8 +120,6 @@ const CHANNEL_MAX = 3;
 
 type DateScenario = "unset" | "past" | "future" | "active";
 
-const NON_PUBLISHED_APPROVAL_STATUSES = new Set(["draft", "awaiting_approval", "rework"]);
-
 interface Offer {
 	account: { set: string }
 	title: string
@@ -138,14 +136,6 @@ interface Offer {
 	post_to_at?: string
 	redeem_from_at?: string
 	redeem_to_at?: string
-	approval_status?: { set: string } | string | null
-}
-
-function isPublished(offer: Offer): boolean {
-	const approvalStatus = typeof offer.approval_status === "string"
-		? offer.approval_status
-		: offer.approval_status?.set;
-	return !approvalStatus || !NON_PUBLISHED_APPROVAL_STATUSES.has(approvalStatus);
 }
 
 function getDateScenario(bucket: number): DateScenario {
@@ -246,10 +236,9 @@ for (let i = 0; i < OFFER_COUNT; i++) {
 		offer.channels = { set: pickDistinct(r, channels, count) };
 	}
 
-	if (isPublished(offer)) {
-		if (!offer.channels) {
-			offer.channels = { set: ["1"] };
-		}
+	// Generated offers are always published, so they must carry at least one channel to be publishable.
+	if (!offer.channels) {
+		offer.channels = { set: ["1"] };
 	}
 
 	if (HAS_LISTINGS_CHANCE > r.random() && listings) {

--- a/scripts/generateOffers.ts
+++ b/scripts/generateOffers.ts
@@ -120,6 +120,8 @@ const CHANNEL_MAX = 3;
 
 type DateScenario = "unset" | "past" | "future" | "active";
 
+const NON_PUBLISHED_APPROVAL_STATUSES = new Set(["draft", "awaiting_approval", "rework"]);
+
 interface Offer {
 	account: { set: string }
 	title: string
@@ -136,6 +138,14 @@ interface Offer {
 	post_to_at?: string
 	redeem_from_at?: string
 	redeem_to_at?: string
+	approval_status?: { set: string } | string | null
+}
+
+function isPublished(offer: Offer): boolean {
+	const approvalStatus = typeof offer.approval_status === "string"
+		? offer.approval_status
+		: offer.approval_status?.set;
+	return !approvalStatus || !NON_PUBLISHED_APPROVAL_STATUSES.has(approvalStatus);
 }
 
 function getDateScenario(bucket: number): DateScenario {
@@ -234,6 +244,14 @@ for (let i = 0; i < OFFER_COUNT; i++) {
 	if (HAS_CHANNELS_CHANCE > r.random()) {
 		const count = r.getRandomIntInclusive(CHANNEL_MIN, CHANNEL_MAX);
 		offer.channels = { set: pickDistinct(r, channels, count) };
+	}
+
+	if (isPublished(offer)) {
+		if (!offer.channels) {
+			offer.channels = { set: ["1"] };
+		} else if (!offer.channels.set.includes("1")) {
+			offer.channels.set.unshift("1");
+		}
 	}
 
 	if (HAS_LISTINGS_CHANCE > r.random() && listings) {

--- a/scripts/generateOffers.ts
+++ b/scripts/generateOffers.ts
@@ -249,8 +249,6 @@ for (let i = 0; i < OFFER_COUNT; i++) {
 	if (isPublished(offer)) {
 		if (!offer.channels) {
 			offer.channels = { set: ["1"] };
-		} else if (!offer.channels.set.includes("1")) {
-			offer.channels.set.unshift("1");
 		}
 	}
 


### PR DESCRIPTION
Ticket: https://jira.granicus.com/browse/DMSMVR-5073

## Summary
- Fix published Listings / Leisure Events / Offers in prepare-demo seed so they meet LEO publish criteria from DMSMVR-4191 (channels, live post windows)
- Correct inverted Post From/To and Redeem From/To on offers
- Generators: always give Website channel `1` to published generated records; keep Phoenix UTC-7 midnight for event `start_date_at` so Prepare Demo does not fail timezone validation
- Draft approval-child records left without channels on purpose (negative cases)

## Test plan
- [x] Execute Script → Prepare Demo → `{ "user": "local" }` on client `test` → ends with **Data setup complete.**
- [x] Offers: no published row with Post To before Post From or Redeem To before Redeem From; NYE offer uses Jan 2027 range
- [x] Listings / Events / Offers grids: filter Channels **not exist** on default grid → **0 rows** (published parents all have channels; draft children are grid-hidden)
- [x] Spot-check Live / Approve on published LEO that previously lacked channels
- [x] Optional A/B: run `{ "user": "simpleviewinc", "branch": "develop" }` then re-run local and compare Live / no-channel counts

## Notes
- Seed-data only in `apex-prepare-demo`; no Apex app code
- Bypass ticket — manual Prepare Demo spot check is the validation (`sv test` / Playwright do not use these seeds)